### PR TITLE
Pin mocha dependency to 2.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/codemix/babel-plugin-typecheck",
   "devDependencies": {
-    "mocha": "^2.2.4",
+    "mocha": "~2.2.4",
     "should": "^6.0.1",
     "babel": "^5.6.0"
   }


### PR DESCRIPTION
This is a quick workaround for a small issue I was having when I first cloned the repo to work on something else.

The dev dependency `"mocha": "^2.2.4"` matches 2.3.x too, which causes `npm run test` / `watch` to fail due to the `--harmony` flag in `mocha.opts` no longer being recognized by mocha `>=2.3`.
A better long-term solution might be to update to the latest mocha and fix the flags accordingly.