### PR TITLE
Support for optional arguments and optional properties of object types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,13 +131,15 @@ export default function build (babel: Object): Object {
     if (types.indexOf('any') > -1 || types.indexOf('mixed') > -1) {
       return null;
     }
+    if (param.optional)
+      types = types.concat("undefined");    
     return t.ifStatement(
       createIfTest(param, types),
       t.throwStatement(
         t.newExpression(
           t.identifier("TypeError"),
           [t.binaryExpression("+",
-            t.literal(`Value of argument '${param.name}' violates contract, expected ${createTypeNameList(types)} got `),
+            t.literal(`Value of ${param.optional ? 'optional argument' : 'argument'} '${param.name}' violates contract, expected ${createTypeNameList(types)} got `),
             createReadableTypeName(param)
           )]
         )
@@ -306,6 +308,8 @@ export default function build (babel: Object): Object {
         type.properties.reduce((expr, prop) => {
           const key = prop.key;
           const valueTypes = extractAnnotationTypes(prop.value);
+          if (prop.optional)
+            valueTypes.push("undefined");
           const test = createIfTest(t.memberExpression(subject, key), valueTypes);
           if (expr === null) {
             return test;

--- a/test/fixtures/optional-arguments.js
+++ b/test/fixtures/optional-arguments.js
@@ -1,0 +1,3 @@
+export default function demo (foo: string, bar?: number): boolean {
+  return foo.length > 0 && bar > 0;
+}

--- a/test/fixtures/optional-properties.js
+++ b/test/fixtures/optional-properties.js
@@ -1,0 +1,6 @@
+export default function demo (input: {
+  greeting: string;
+  id?: number;
+}): boolean {
+  return false;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,18 @@ describe('Typecheck', function () {
 
   failWith("Function 'demo' return value violates contract, expected number or string got Object", "conditional-return-value", {a: 123});
 
+  ok("optional-properties", {greeting: "hello world", id: 123});
+  ok("optional-properties", {greeting: "hello world"});
+  failWith("Value of argument 'input' violates contract, expected Object with properties greeting and id got Object", "optional-properties", {greeting: "hello world", id: "123"});
+  failWith("Value of argument 'input' violates contract, expected Object with properties greeting and id got Object", "optional-properties", {greeting: "hello world", id: null});
+  failWith("Value of argument 'input' violates contract, expected Object with properties greeting and id got Object", "optional-properties", {id: 123});
+  failWith("Value of argument 'input' violates contract, expected Object with properties greeting and id got Object", "optional-properties", {foo: "bar"});
+  failWith("Value of argument 'input' violates contract, expected Object with properties greeting and id got string", "optional-properties", "foo");
+
+  ok("optional-arguments", "hello world");
+  ok("optional-arguments", "hello world", 123);
+  failWith("Value of optional argument 'bar' violates contract, expected number or undefined got string", "optional-arguments", "hello world", "123");
+  failWith("Value of optional argument 'bar' violates contract, expected number or undefined got null", "optional-arguments", "hello world", null);
 });
 
 


### PR DESCRIPTION
The added functionality and tests reflect my understanding of Flow's [optional properties](http://flowtype.org/docs/objects.html#optional-properties) and [optional arguments] (http://flowtype.org/docs/functions.html#variadics) semantics.

Optional arguments use the `x?: T` syntax that the Flow docs [mention in passing] (http://flowtype.org/docs/functions.html#function-based-type-annotations).