### PR TITLE
Add support for QualifiedTypeIdentifier form

### DIFF
--- a/test/fixtures/qualified-types.js
+++ b/test/fixtures/qualified-types.js
@@ -1,0 +1,8 @@
+let T = {
+  Object,
+  Array,
+}
+
+export default function demo (foo: T.Object|T.Array): boolean {
+  return true
+}

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,9 @@ describe('Typecheck', function () {
   ok("default-arguments", "hello world", 123);
   failWith("Value of argument 'bar' violates contract, expected number got string", "default-arguments", "hello world", "123");
   failWith("Value of argument 'bar' violates contract, expected number got null", "default-arguments", "hello world", null);
+
+  ok("qualified-types", {})
+  failWith("Value of argument 'foo' violates contract, expected T.Object or T.Array got string", "qualified-types", "hello")
 });
 
 


### PR DESCRIPTION
When you write `function f2 (to: X.Y.Z.Type) {}` we currently get a duck typing fail with Babel's AST and we generate deficient code. This adds support for this form – it resolves `X.Y.Z.Type` like an expression.