### PR TITLE
Support for VariableDeclaration and fix for ArrowFunctionExpression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,13 @@ export default function build (babel: Object): Object {
     },
     Function (node: Object, parent: Object, scope: Object) {
       try {
+        if (node.typeParameters != null) {
+          throw this.errorWithNode('Type parameters are not supported');
+        }
+
         const argumentGuards = createArgumentGuards(node);
         const returnTypes = extractReturnTypes(node);
+
         if (argumentGuards.length > 0 || returnTypes.length > 0) {
           if (node.type === "ArrowFunctionExpression" && node.expression) {
             node.expression = false;

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,22 @@ export default function build (babel: Object): Object {
   ];
 
   return new Transformer("typecheck", {
+    Program (node: Object, parent: Object, scope: Object) {
+      try {
+        this.traverse(visitors, {
+          constants: scope.getAllBindingsOfKind("const"),
+          subject: node,
+        });
+      }
+      catch (e) {
+        if (e instanceof SyntaxError) {
+          throw this.errorWithNode(e.message);
+        }
+        else {
+          throw e;
+        }
+      }
+    },
     Function (node: Object, parent: Object, scope: Object) {
       try {
         const argumentGuards = createArgumentGuards(node);
@@ -113,7 +129,7 @@ export default function build (babel: Object): Object {
   /**
    * Create guards for the typed arguments of the function.
    */
-  function createArgumentGuards (node: Object): Array<Object|string> {
+  function createArgumentGuards (node: Object): Array<Object> {
     return node.params.reduce(
       (guards, param) => {
         if (param.type === "AssignmentPattern" && param.left.typeAnnotation) {
@@ -163,6 +179,42 @@ export default function build (babel: Object): Object {
       throw new SyntaxError(`Default value for argument '${param.left.name}' violates contract, expected ${createTypeNameList(types)}`);
     }
     return createArgumentGuard(param.left, types);
+  }
+
+
+  /**
+   * Create guards for a variable declaration statement.
+   */
+  function createVariableGuards (node : Object) : Array<Object> {
+    let guards = []
+    node.declarations.forEach(declaration => {
+      if(declaration.id.typeAnnotation) {
+        guards.push(createVariableGuard(declaration.id, extractAnnotationTypes(declaration.id.typeAnnotation)))
+      }
+    })
+    return guards
+  }
+
+
+  /**
+   * Create a guard for a variable identifier.
+   */
+  function createVariableGuard (id: Object, types: Array<Object|string>) {
+    if (types.indexOf('any') > -1 || types.indexOf('mixed') > -1) {
+      return null;
+    }
+    return t.ifStatement(
+      createIfTest(id, types),
+      t.throwStatement(
+        t.newExpression(
+          t.identifier("TypeError"),
+          [t.binaryExpression("+",
+            t.literal(`Value of variable '${id.name}' violates contract, expected ${createTypeNameList(types)} got `),
+            createReadableTypeName(id)
+          )]
+        )
+      )
+    );
   }
 
 
@@ -531,7 +583,7 @@ export default function build (babel: Object): Object {
       // will visit them for us and it keeps things a *lot* simpler.
       return this.skip();
     }
-    else if (node == state.subject.body) {
+    else if (state.argumentGuards != null && node === state.subject.body) {
       if (node.type === "BlockStatement") {
         // attach the argument guards to the first block statement in the function body
         return t.blockStatement(
@@ -549,7 +601,7 @@ export default function build (babel: Object): Object {
    */
   function exitNode (node: Object, parent: Object, scope: Object, state: Object) {
     if (node.type === 'ReturnStatement') {
-      if (state.returnTypes.length === 0) {
+      if (state.returnTypes != null && state.returnTypes.length === 0) {
         // we only care about typed return statements.
         return;
       }
@@ -572,6 +624,20 @@ export default function build (babel: Object): Object {
         const ref = createReferenceTo(this, node.argument, scope);
         this.insertBefore(createReturnTypeGuard(ref, node, scope, state));
         return t.returnStatement(ref);
+      }
+    }
+    else if (node.type === 'VariableDeclaration') {
+      if (parent.type === 'BlockStatement' || parent.type == 'Program') {
+        this.insertAfter(createVariableGuards(node));
+      }
+      else if (
+        parent.type === 'ForStatement' ||
+        parent.type === 'ForOfStatement' ||
+        parent.type === 'ForInStatement') {
+        parent.body = t.blockStatement([].concat(createVariableGuards(node), parent.body.body));
+      }
+      else {
+        throw this.errorWithNode('Can\'t insert type check here');
       }
     }
   }

--- a/test/fixtures/arrow-function-2.js
+++ b/test/fixtures/arrow-function-2.js
@@ -1,0 +1,4 @@
+export default function demo (input) {
+  let func = (arg : number) => arg
+  return func(input)
+}

--- a/test/fixtures/arrow-function.js
+++ b/test/fixtures/arrow-function.js
@@ -1,0 +1,6 @@
+export default function demo (input) {
+  let func = (arg : number) => {
+    let x : number = arg
+  }
+  return func(input)
+}

--- a/test/fixtures/var-declarations.js
+++ b/test/fixtures/var-declarations.js
@@ -1,0 +1,6 @@
+export default function demo (input): boolean {
+  let a : Array = input
+  for(let b : string of a) {
+    let c : string = b
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,11 @@ describe('Typecheck', function () {
   failWith("Value of variable 'a' violates contract, expected array got string", "var-declarations", "abc")
   failWith("Value of variable 'b' violates contract, expected string got number", "var-declarations", ["abc", 123])
 
+  ok("arrow-function", 123)
+  ok("arrow-function-2", 123)
+
+  failWith("Value of argument 'arg' violates contract, expected number got string", "arrow-function", "abc")
+  failWith("Value of argument 'arg' violates contract, expected number got string", "arrow-function-2", "abc")
 });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,11 @@ describe('Typecheck', function () {
 
   ok("qualified-types", {})
   failWith("Value of argument 'foo' violates contract, expected T.Object or T.Array got string", "qualified-types", "hello")
+
+  ok("var-declarations", ["abc", "123"])
+  failWith("Value of variable 'a' violates contract, expected array got string", "var-declarations", "abc")
+  failWith("Value of variable 'b' violates contract, expected string got number", "var-declarations", ["abc", 123])
+
 });
 
 


### PR DESCRIPTION
Arrow functions needed a fix for when the body is an expression.

Added type checking for variables at declaration time.