### PR TITLE
Ignore generic functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build-typed",
     "test": "mocha",
-    "watch": "mocha --watch"
+    "watch": "NODE_WATCH=1 mocha --watch"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/fancy-generic-function.js
+++ b/test/fixtures/fancy-generic-function.js
@@ -1,0 +1,3 @@
+export default function demo <T> (buffer: Buffer<T>, callback: (value: T) => number): number {
+  return callback(buffer[0]);
+}

--- a/test/fixtures/generic-function.js
+++ b/test/fixtures/generic-function.js
@@ -1,0 +1,3 @@
+export default function demo <T>(value: T): T {
+  return value;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,12 @@
-import typecheck from '../lib';
 import fs from 'fs';
 import {parse, transform, traverse} from 'babel';
+
+if (process.env.NODE_WATCH) {
+  var typecheck = require('../src');
+}
+else {
+  var typecheck = require('../lib');
+}
 
 describe('Typecheck', function () {
   ok("fancy-generic-function", Buffer(123), (value) => value);

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@ import fs from 'fs';
 import {parse, transform, traverse} from 'babel';
 
 describe('Typecheck', function () {
+  ok("fancy-generic-function", Buffer(123), (value) => value);
+  ok("generic-function", 123);
   ok("return-object-types", {greeting: "hello world", id: 123});
   failWith("Function 'demo' return value violates contract, expected Object with properties greeting and id got Object", "return-object-types", {foo: "bar"});
 


### PR DESCRIPTION
Can't sensibly support generic types in this version, but we can track them and ignore them in most cases - fixes #28 