### PR TITLE
Fix rest params (#36)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ export default function build (babel: Object): Object {
         }
         else if (param.type === "RestElement" && param.typeAnnotation) {
           const types = extractAnnotationTypes(param.typeAnnotation);
-          if (types.indexOf("array") === -1)
+          if (!types.includes("array") || types.some(t => t !== "array"))
             throw new SyntaxError(`Annotation for rest argument '...${param.argument.name}' must be an array type`);
         }
         else if (param.typeAnnotation) {

--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,11 @@ export default function build (babel: Object): Object {
         if (param.type === "AssignmentPattern" && param.left.typeAnnotation) {
           guards.push(createDefaultArgumentGuard(param, extractAnnotationTypes(param.left.typeAnnotation), genericTypes));
         }
+        else if (param.type === "RestElement" && param.typeAnnotation) {
+          const types = extractAnnotationTypes(param.typeAnnotation);
+          if (types.indexOf("array") === -1)
+            throw new SyntaxError(`Annotation for rest argument '...${param.argument.name}' must be an array type`);
+        }
         else if (param.typeAnnotation) {
           guards.push(createArgumentGuard(param, extractAnnotationTypes(param.typeAnnotation), genericTypes));
         }

--- a/test/fixtures/bad-rest-params-2.js
+++ b/test/fixtures/bad-rest-params-2.js
@@ -1,0 +1,9 @@
+function countArgs(...args: Array<number>|number): number
+{
+	return args.length;
+}
+
+export default function test(): number
+{
+	return countArgs();
+}

--- a/test/fixtures/bad-rest-params.js
+++ b/test/fixtures/bad-rest-params.js
@@ -1,0 +1,9 @@
+function countArgs(...args: number): number
+{
+	return args.length;
+}
+
+export default function test(): number
+{
+	return countArgs();
+}

--- a/test/fixtures/rest-params.js
+++ b/test/fixtures/rest-params.js
@@ -3,6 +3,12 @@ export default function countArgs(...args: Array<number>): number
 	return args.length;
 }
 
+export default function countArgs2(...args2: Array<number>|Array<string>): number
+{
+	return args2.length;
+}
+
 function noAnnotation(...unannotated) {
+	countArgs2(...unannotated);
 	return countArgs(...unannotated);
 }

--- a/test/fixtures/rest-params.js
+++ b/test/fixtures/rest-params.js
@@ -1,0 +1,8 @@
+export default function countArgs(...args: Array<number>): number
+{
+	return args.length;
+}
+
+function noAnnotation(...unannotated) {
+	return countArgs(...unannotated);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,7 @@ describe('Typecheck', function () {
   ok("rest-params", 1);
   ok("rest-params", 10, 20);
   failStatic("bad-rest-params");
+  failStatic("bad-rest-params-2");
 });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,11 @@ describe('Typecheck', function () {
   failWith("Value of argument 'arg' violates contract, expected number got string", "arrow-function-2", "abc")
 
   ok("bug-30-conditional-return");
+
+  ok("rest-params");
+  ok("rest-params", 1);
+  ok("rest-params", 10, 20);
+  failStatic("bad-rest-params");
 });
 
 


### PR DESCRIPTION
As the `T` in `Array<T>` is not checked right now, and the `...`-to-`Array` desugaring is internal to Babel, I elected to remove the runtime check here entirely and convert it to a modest static check that the annotation indeed asks for an array type.

By the way, should this check be stricter and enforce that `types` be _exactly_ `["array"]`?