### PR TITLE
Save transformed test fixtures to disk via an env setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .settings
 node_modules
 lib
+*.transformed
+npm-debug.log

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,8 @@ function load (basename) {
   const context = {
     exports: {}
   };
+  if (process.env.TYPECHECK_SAVE_TRANSFORMED)
+    fs.writeFileSync(`${__dirname}/fixtures/${basename}.js.transformed`, transformed.code, 'utf8');
   const loaded = new Function('module', 'exports', transformed.code);
   loaded(context, context.exports);
   return context.exports;


### PR DESCRIPTION
This is self-explanatory. It has helped me debug and fix some issues recently.
Bikeshed issues - what should the variable be called, what should the output files be called, where should they be saved etc. This is what works well enough for me.