### PR TITLE
Guard against `node.declaration` being null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export default function ({types: t, template}): Object {
 
       ExportNamedDeclaration (path: NodePath): void {
         const {node, scope} = path;
-        if (node.declaration.type === 'TypeAlias') {
+        if (node.declaration && node.declaration.type === 'TypeAlias') {
           path.replaceWith(t.exportNamedDeclaration(
             createTypeAliasChecks(path.get('declaration')),
             [],

--- a/test/fixtures/export-type.js
+++ b/test/fixtures/export-type.js
@@ -11,3 +11,6 @@ export default function demo (input: User): User {
   const saved = input;
   return saved;
 }
+
+const wat2 = 321;
+export {wat2};


### PR DESCRIPTION
Seems I caught an edge case for the ES6 export syntax. 

I checked the spec and `declaration` can, indeed, be null. https://github.com/estree/estree/blob/master/es6.md#exportnameddeclaration