### PR TITLE
Prepare 3.0.2

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "stage-1",
+    "stage-0",
     "es2015"
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,5 @@
     "es2015"
   ],
   "plugins": [
-    "syntax-flow",
-    "transform-flow-strip-types"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-typecheck",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel -d ./lib ./src",
-    "build-typed": "npm run build && babel --plugins ./lib -d ./lib-checked ./src",
+    "build": "babel --plugins syntax-flow,transform-flow-strip-types -d ./lib ./src",
+    "build-typed": "npm run build && babel --plugins ./lib,syntax-flow,transform-flow-strip-types -d ./lib-checked ./src",
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "test": "mocha ./test/index.js",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
   "devDependencies": {
     "babel-cli": "^6.1.0",
     "babel-core": "^6.1.0",
+    "babel-plugin-syntax-class-properties": "^6.1.18",
     "babel-polyfill": "^6.0.16",
     "babel-preset-es2015": "^6.1.0",
     "babel-preset-react": "^6.1.0",
+    "babel-preset-stage-0": "^6.1.18",
     "babel-preset-stage-1": "^6.1.0",
     "mocha": "~2.2.4",
     "should": "^6.0.1"
@@ -44,7 +46,6 @@
   "dependencies": {
     "babel-generator": "^6.1.2",
     "babel-plugin-syntax-flow": "^6.0.14",
-    "babel-plugin-transform-es2015-instanceof": "^6.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
     "babel-plugin-transform-flow-strip-types": "^6.0.14"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -289,6 +289,9 @@ export default function ({types: t, template}): Object {
           if (path.parent.type === 'Program' || path.parent.type === 'BlockStatement') {
             path.insertAfter(check);
           }
+          else if (path.parent.type === 'ExportNamedDeclaration' || path.parent.type === 'ExportDefaultDeclaration' || path.parent.type === 'ExportAllDeclaration') {
+            path.parentPath.insertAfter(check);
+          }
           else {
             path.replaceWith(t.blockStatement([node, check]));
           }

--- a/test-polyfill.js
+++ b/test-polyfill.js
@@ -1,7 +1,7 @@
 require("babel-core/register")({
   "presets": ["stage-1", "es2015"],
   "plugins": [
-    "syntax-flow",
+    //"syntax-flow",
     "transform-flow-strip-types"
   ]
 });

--- a/test/fixtures/bad-map-values.js
+++ b/test/fixtures/bad-map-values.js
@@ -1,7 +1,7 @@
 export default function demo (input: Map<string, *>): Map<*, number> {
   const converted = new Map();
   for (let [key, value] of input) {
-    converted.set(key, value);
+    converted.set(value, key);
   }
   return converted;
 }

--- a/test/fixtures/bug-xxx-export.js
+++ b/test/fixtures/bug-xxx-export.js
@@ -1,0 +1,6 @@
+import {User} from './export-class';
+
+export default function demo () {
+  let user;
+  user = new User();
+};

--- a/test/fixtures/class-getter.js
+++ b/test/fixtures/class-getter.js
@@ -1,0 +1,19 @@
+class User {
+  constructor (name) {
+    this.name = name;
+  }
+
+  get length (): number {
+    return this.name.length;
+  }
+
+  get minusLength (): number {
+    return -this.length;
+  }
+}
+
+export default function demo (name: string): number {
+  const user = new User(name);
+  return user.length;
+}
+

--- a/test/fixtures/export-class.js
+++ b/test/fixtures/export-class.js
@@ -1,0 +1,8 @@
+export class User {}
+
+export type UserCollection = User[];
+
+export default function demo (input: User): UserCollection {
+  const saved = input;
+  return [saved];
+}

--- a/test/fixtures/export-type.js
+++ b/test/fixtures/export-type.js
@@ -3,7 +3,7 @@ export type User = {
   age: number
 };
 
-export type UserCollection = Array<User>;
+export type UserCollection = User[];
 
 export const wat = 123;
 

--- a/test/fixtures/export-typed-var.js
+++ b/test/fixtures/export-typed-var.js
@@ -1,0 +1,9 @@
+type User = {
+  name: string;
+}
+
+export const user: User = {name: 'foo'};
+
+export default function demo (input: string): number {
+  return input.length;
+}

--- a/test/fixtures/new.js
+++ b/test/fixtures/new.js
@@ -1,0 +1,13 @@
+class User {
+  constructor (name: string) {
+    this.name = name;
+  }
+}
+
+export default function demo (name: string): any {
+  let user: ?User;
+  (() => {
+    user = new User(name);
+  })();
+  return user;
+}

--- a/test/fixtures/symbols.js
+++ b/test/fixtures/symbols.js
@@ -1,0 +1,8 @@
+export default function demo (input: Symbol): Symbol {
+  return createSymbol('wat');
+}
+
+
+function createSymbol (label) {
+  return Symbol(label);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,7 @@ describe('Typecheck', function () {
 
   ok('map-keys', new Map([['a', 1], ['b', 2], ['c', 3]]));
   ok('map-values', new Map([['a', 1], ['b', 2], ['c', 3]]));
+  failWith(`Function "demo" return value violates contract, expected Map<*, number> got Map`, 'bad-map-values', new Map([['a', 1], ['b', 2], ['c', 3]]));
 
   ok('map-contents', new Map([['a', 1], ['b', 2], ['c', 3]]));
   failWith('Value of argument "input" violates contract, expected Map<string, number> got Map', 'map-contents', new Map([['a', 1], ['b', 2], ['c', 'nope']]));

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok("bug-xxx-export");
   ok('new', 'bob');
   ok('symbols', Symbol('foo'));
   failWith(`Value of argument "input" violates contract, expected Symbol got string`, 'symbols', 'wat');

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('class-getter', 'alice');
   ok("bug-xxx-export");
   ok('new', 'bob');
   ok('symbols', Symbol('foo'));
@@ -191,13 +192,13 @@ function loadInternal (basename) {
   const transformed = transform(source, {
     filename: filename,
     presets: [
-      "stage-1",
-      "es2015"
+      "es2015",
+      "stage-0",
     ],
     plugins: [
       typecheck,
       'transform-flow-strip-types',
-      //'transform-es2015-instanceof'
+      'syntax-class-properties'
     ]
   });
   const context = {

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,8 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('symbols', Symbol('foo'));
+  failWith(`Value of argument "input" violates contract, expected Symbol got string`, 'symbols', 'wat');
   ok('export-typed-var', 'foo');
   ok('bug-48-export-star', 'wat');
   ok('typeof', {name: 'bob'});

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('export-typed-var', 'foo');
   ok('bug-48-export-star', 'wat');
   ok('typeof', {name: 'bob'});
   failWith('Value of argument "input" violates contract, expected typeof user got Object', 'typeof', {name: false});

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('new', 'bob');
   ok('symbols', Symbol('foo'));
   failWith(`Value of argument "input" violates contract, expected Symbol got string`, 'symbols', 'wat');
   ok('export-typed-var', 'foo');
@@ -171,6 +172,11 @@ describe('Typecheck', function () {
   ok("import-type", {name: "Bob", age: 45});
   ok("import-multiple-types", [{name: "Bob", age: 45}]);
   ok('conditional-expression', 'foo');
+
+  it(`should load itself`, function () {
+    this.timeout(30000); // @fixme We are currently unacceptably slow.
+    load('/../../src/index');
+  });
 });
 
 function load (basename) {


### PR DESCRIPTION
Fixes some bugs with export declarations, null checks and stops static verification from swallowing runtime checks for Map and Sets.