### PR TITLE
Add pragmas

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,26 @@ demo({name: "test", email: "test@test.com"}); // ok
 ```
 
 
+## Pragmas
+
+Sometimes you might need to disable type checking for a particular file or section of code.
+To ignore an entire file, add a comment at the top level scope of the file:
+```js
+// typecheck: ignore file
+export function wrong (input: string = 123): boolean {
+  return input + ' nope';
+}
+```
+
+To ignore a particular statement:
+```js
+let foo: string = "hello world";
+// typecheck: ignore statement
+foo = 123;
+```
+
+> Note: Because of how typecheck works, it's not possible to ignore individual lines, only entire statements or files.
+> So if you ignore e.g. an if statement, the entire body of that statement will be ignored.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-typecheck",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/pragma-ignore-file.js
+++ b/test/fixtures/pragma-ignore-file.js
@@ -1,0 +1,5 @@
+// typecheck: ignore file
+
+export default function demo (input: string = false): number {
+  return false;
+}

--- a/test/fixtures/pragma-ignore-statement.js
+++ b/test/fixtures/pragma-ignore-statement.js
@@ -1,0 +1,23 @@
+/**
+ * Do something
+ */
+export default function demo (input: string): number {
+
+  /* typecheck: ignore statement */
+  let foo: string = 123;
+
+  /* typecheck: ignore statement */
+  foo = 123;
+
+  return input.length * 2;
+}
+
+// typecheck: ignore statement
+function badFnLine (input: string = 123): boolean {
+  return input;
+}
+
+/* typecheck: ignore statement */
+function badFnBlock (input: string = 123): boolean  {
+  return input;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,9 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('pragma-ignore-statement', 'some string');
+  ok('pragma-ignore-file', 'some string');
+
   ok('async-method', ['hello world']);
   ok('async-function', ['hello world']);
   failWith(`Value of argument "input" violates contract, expected string[] got Array`, 'async-function', [123]);


### PR DESCRIPTION
Can now use `// typecheck: ignore file` to ignore an entire file, or `//typecheck ignore statement` to ignore an entire statement (and all its children)

Fixes #54 
