### PR TITLE
Support Iterable<type> and NextType in generator functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-typecheck",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -266,15 +266,15 @@ export default function ({types: t, template}): Object {
 
 
     ReturnStatement (path: NodePath): void {
-      if (maybeSkip(path)) {
-        return;
-      }
-      const {node, parent, scope} = path;
       const fn = path.getFunctionParent();
       if (!fn) {
         return;
       }
       fn.node.returnCount++;
+      if (maybeSkip(path)) {
+        return;
+      }
+      const {node, parent, scope} = path;
       const {returnType} = fn.node;
       if (!returnType) {
         return;

--- a/test/fixtures/bad-iterable-type.js
+++ b/test/fixtures/bad-iterable-type.js
@@ -1,0 +1,7 @@
+export default function demo (input: Iterable<number>): number {
+  let total = 0;
+  for (let item: string of input) {
+    total += item;
+  }
+  return total;
+}

--- a/test/fixtures/bad-iterable.js
+++ b/test/fixtures/bad-iterable.js
@@ -1,0 +1,7 @@
+export default function demo (input: number): number {
+  let total = 0;
+  for (let item: string of input) {
+    total += item;
+  }
+  return total;
+}

--- a/test/fixtures/bug-68-return-string-literal.js
+++ b/test/fixtures/bug-68-return-string-literal.js
@@ -1,0 +1,17 @@
+export default function demo (): string {
+    return foo();
+}
+
+function foo (): string {
+  return 'foo';
+}
+
+class Foo {
+  constructor() {
+    this.ret = '';
+  }
+
+  MyFunction(): string {
+    return this.ret;
+  }
+}

--- a/test/fixtures/generators-with-next.js
+++ b/test/fixtures/generators-with-next.js
@@ -1,0 +1,19 @@
+export default function demo <T> (input: T): T[] {
+  const items = [];
+  const it = gen();
+  let next;
+  while (!(next = it.next(input)).done) {
+    let yieldedValue = next.value;
+    items.push(yieldedValue);
+  }
+  return items;
+}
+
+
+function* gen (): Generator<number, boolean, number> {
+  let last: number = 0;
+  last = yield 1;
+  last = yield 2 + last;
+  last = yield 3 + last;
+  return true;
+}

--- a/test/fixtures/iterable.js
+++ b/test/fixtures/iterable.js
@@ -1,0 +1,7 @@
+export default function demo (input: Iterable<number>): number {
+  let total = 0;
+  for (let item: number of input) {
+    total += item;
+  }
+  return total;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,9 @@ describe('Typecheck', function () {
   ok('object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: false, a: 123}});
   ok('generators', 'foo');
   failWith(`Function "gen"  yielded an invalid value, expected number | string got boolean`, 'generators', false);
+  ok('generators-with-next', 12);
+  failWith(`Generator "gen" received an invalid next value, expected number got string`, 'generators-with-next', 'foo');
+  failWith(`Generator "gen" received an invalid next value, expected number got boolean`, 'generators-with-next', false);
   failStatic('bad-generators', 'foo');
   failStatic('bad-generators-return', 'foo');
   ok('object-properties-function', 'bob', 'bob@example.com');

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,11 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('iterable', [1, 2, 3]);
+  failWith(`Value of variable "item" violates contract, expected number got string`, 'iterable', ['a', 'b', 'c']);
+  failStatic('bad-iterable', [1, 2, 3]);
+  failStatic('bad-iterable-type', 123);
+
   ok('bug-68-return-string-literal');
   ok('indexers', foo => null);
   ok('object-pattern', {a: 'foo', b: 34});

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('bug-68-return-string-literal');
   ok('indexers', foo => null);
   ok('object-pattern', {a: 'foo', b: 34});
   ok('object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: false, a: 123}});


### PR DESCRIPTION
`Generator` now takes 3 type parameters - `Generator<YieldType, ReturnType, NextType>`.

Adds support for `Iterable<someType>`, fixes #69 

Also adds a potential fix for #68 but was unable to replicate to verify.