### PR TITLE
Fix #71 - cannot iterate void

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -495,6 +495,9 @@ export default function ({types: t, template}): Object {
     },
 
     ForOfStatement (path: NodePath): void {
+      if (maybeSkip(path)) {
+        return;
+      }
       const left: NodePath = path.get('left');
       const right: NodePath = path.get('right');
       const rightAnnotation: TypeAnnotation = getAnnotation(right);
@@ -520,6 +523,13 @@ export default function ({types: t, template}): Object {
           message: t.stringLiteral(`Expected ${generate(right.node).code} to be iterable, got ${readableName({input: id})}`)
         }));
       }
+
+      right.node.hasBeenTypeChecked = true;
+      right.hasBeenTypeChecked = true;
+      left.node.hasBeenTypeChecked = true;
+      left.hasBeenTypeChecked = true;
+      path.node.hasBeenTypeChecked = true;
+      path.hasBeenTypeChecked = true;
 
       if (rightAnnotation.type !== 'GenericTypeAnnotation' || rightAnnotation.id.name !== 'Iterable' || !rightAnnotation.typeParameters || !rightAnnotation.typeParameters.params.length) {
         return;

--- a/src/index.js
+++ b/src/index.js
@@ -520,7 +520,11 @@ export default function ({types: t, template}): Object {
         }
         path.insertBefore(guard({
           check: checks.iterable({input: id}),
-          message: t.stringLiteral(`Expected ${generate(right.node).code} to be iterable, got ${readableName({input: id})}`)
+          message: t.binaryExpression(
+            '+',
+            t.stringLiteral(`Expected ${generate(right.node).code} to be iterable, got `),
+            readableName({input: id})
+          )
         }));
       }
 

--- a/test/fixtures/bug-71-cannot-iterate-void.js
+++ b/test/fixtures/bug-71-cannot-iterate-void.js
@@ -10,10 +10,18 @@ class Foo {
       got.push(f);
     }
   }
+
+  myFunction2(): void {
+    for (f of this.foo) {
+      got.push(f);
+    }
+    var f;
+  }
 }
 
 export default function demo (): string[] {
   const foo = new Foo ();
   foo.myFunction();
+  foo.myFunction2();
   return got;
 }


### PR DESCRIPTION
This is working around a probable babel type inference issue but it's convoluted enough that I can't pin it down right now. It does seem that when using `babel-register` it's possible for the plugin ordering to be subtly affected, but I can't see any obvious causes for that. This works around the issue raised in #71 by simply skipping the static check if we detect signs of the problem.

Fixes #71 but not in an ideal way.