### PR TITLE
Handle class annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-typecheck",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/class-annotation.js
+++ b/test/fixtures/class-annotation.js
@@ -1,0 +1,4 @@
+export default function demo (input: Class): Class {
+  input.prototype.foo = () => 'bar';
+  return input;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,15 @@ else {
 describe('Typecheck', function () {
   ok('class-annotation', class Thing {});
   failWith(`Value of argument "input" violates contract, expected Class got boolean`, 'class-annotation', false);
+
+  if (!(() => true).prototype) {
+    failWith(`Value of argument "input" violates contract, expected Class got function`, 'class-annotation', () => true);
+  }
+  else {
+    // environment does not support spec compliant arrow functions.
+    it.skip(`Value of argument "input" violates contract, expected Class got function`);
+  }
+
   ok('bug-83-spread-object', {a: 1, b: 2, c: 3});
   ok('bug-82-too-much-inference');
   ok('bug-xxx-assignment-expression');

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,8 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('class-annotation', class Thing {});
+  failWith(`Value of argument "input" violates contract, expected Class got boolean`, 'class-annotation', false);
   ok('bug-83-spread-object', {a: 1, b: 2, c: 3});
   ok('bug-82-too-much-inference');
   ok('bug-xxx-assignment-expression');


### PR DESCRIPTION
Adds rudimentary support for `Class`, which simply checks that the value is a function with a prototype.

Partially fixes #73 