### PR TITLE
split object inspector into per-file helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-typecheck",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Transforms flow type annotations into runtime type checks.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -620,18 +620,21 @@ export default function ({types: t, template}): Object {
               else if (input === undefined) {
                 return 'undefined';
               }
-              else if (typeof input === 'string') {
-                return JSON.stringify(input.length > 32 ? input.slice(0, 32) + '...' : input);
-              }
-              else if (typeof input === 'number' || typeof input === 'boolean') {
-                return input + '';
+              else if (typeof input === 'string' || typeof input === 'number' || typeof input === 'boolean') {
+                return typeof input;
               }
               else if (Array.isArray(input)) {
-                if (input.length > 8) {
-                  return '[\\n' + input.map(id).join(',\\n  ') + '\\n]';
+                if (input.length > 0) {
+                  var first = id(input[0]);
+                  if (input.every(item => id(item) === first)) {
+                    return first.trim() + '[]';
+                  }
+                  else {
+                    return '[' + input.map(id).join(', ') + ']';
+                  }
                 }
                 else {
-                  return '[' + input.map(id).join(', ') + ']';
+                  return 'Array';
                 }
               }
               else {
@@ -645,13 +648,13 @@ export default function ({types: t, template}): Object {
                   }
                 }
                 var entries = keys.map(key => {
-                  return JSON.stringify(key) + ': ' + id(input[key]);
-                }).join(',\\n  ');
+                  return (/^([A-Z_$][A-Z0-9_$]*)$/i.test(key) ? key : JSON.stringify(key)) + ': ' + id(input[key]) + ';';
+                }).join('\\n  ');
                 if (input.constructor && input.constructor.name && input.constructor.name !== 'Object') {
                   return input.constructor.name + ' {\\n  ' + entries + '\\n}';
                 }
                 else {
-                  return '{\\n  ' + entries + '\\n}';
+                  return '{ ' + entries + '\\n}';
                 }
               }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -116,10 +116,6 @@ export default function ({types: t, template}): Object {
     }
   `);
 
-  const inspector: (() => Node) = expression(`
-    input === null ? 'null' : typeof input === 'object' && input.constructor ? input.constructor.name || '[Unknown Object]' : typeof input
-  `);
-
   const readableName: (() => Node) = expression(`
     inspect(input)
   `);
@@ -259,7 +255,12 @@ export default function ({types: t, template}): Object {
           if (node.generator && isGeneratorAnnotation(annotation) && annotation.typeParameters && annotation.typeParameters.params.length > 1) {
             annotation = annotation.typeParameters.params[1];
           }
-          throw path.buildCodeFrameError(`Function ${node.id ? `"${node.id.name}" ` : ''}did not return a value, expected ${humanReadableType(annotation)}`);
+          throw path.buildCodeFrameError(
+            buildErrorMessage(
+              `Function ${node.id ? `"${node.id.name}" ` : ''}did not return a value.`,
+              annotation
+            )
+          );
         }
         if (node.nextGuardCount) {
           path.get('body').get('body')[0].insertBefore(node.nextGuard);
@@ -298,7 +299,13 @@ export default function ({types: t, template}): Object {
         return;
       }
       else if (ok === false) {
-        throw path.buildCodeFrameError(`Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}yielded an invalid type, expected ${humanReadableType(yieldType)} got ${humanReadableType(getAnnotation(path.get('argument')))}`);
+        throw path.buildCodeFrameError(
+          buildErrorMessage(
+            `Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}yielded an invalid type.`,
+            yieldType,
+            getAnnotation(path.get('argument'))
+          )
+        );
       }
       fn.node.yieldGuardCount++;
       if (fn.node.yieldGuard) {
@@ -338,7 +345,12 @@ export default function ({types: t, template}): Object {
       }
       if (!node.argument) {
         if (maybeNullableAnnotation(returnType) === false) {
-          throw path.buildCodeFrameError(`Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}did not return a value, expected ${humanReadableType(returnType)}`);
+          throw path.buildCodeFrameError(
+            buildErrorMessage(
+              `Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}did not return a value.`,
+              returnType
+            )
+          );
         }
         return;
       }
@@ -354,7 +366,13 @@ export default function ({types: t, template}): Object {
         return;
       }
       else if (ok === false) {
-        throw path.buildCodeFrameError(`Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}returned an invalid type, expected ${humanReadableType(annotation)} got ${humanReadableType(getAnnotation(path.get('argument')))}`);
+        throw path.buildCodeFrameError(
+          buildErrorMessage(
+            `Function ${fn.node.id ? `"${fn.node.id.name}" ` : ''}returned an invalid type.`,
+            annotation,
+            getAnnotation(path.get('argument'))
+          )
+        );
       }
       fn.node.returnGuardCount++;
       const returner = t.returnStatement(t.callExpression(fn.node.returnGuardName, [node.argument]));
@@ -382,7 +400,13 @@ export default function ({types: t, template}): Object {
           continue;
         }
         else if (ok === false) {
-          throw path.buildCodeFrameError(`Invalid assignment value, expected ${humanReadableType(id.typeAnnotation)} got ${humanReadableType(getAnnotation(declarations[i]))}`);
+          throw path.buildCodeFrameError(
+            buildErrorMessage(
+              `Invalid assignment value for "${id.name}".`,
+              id.typeAnnotation,
+              getAnnotation(declarations[i])
+            )
+          );
         }
         const check = checkAnnotation(id, id.typeAnnotation, scope);
         if (check) {
@@ -468,7 +492,13 @@ export default function ({types: t, template}): Object {
         return;
       }
       else if (ok === false) {
-        throw path.buildCodeFrameError(`Invalid assignment value, expected ${humanReadableType(annotation)} got ${humanReadableType(getAnnotation(right))}`);
+        throw path.buildCodeFrameError(
+          buildErrorMessage(
+            `Invalid assignment value for "${humanReadableType(id)}".`,
+            annotation,
+            getAnnotation(right)
+          )
+        );
       }
       const check = checkAnnotation(id, annotation, scope);
       if (!id.typeAnnotation) {
@@ -516,7 +546,7 @@ export default function ({types: t, template}): Object {
       if (rightAnnotation.type !== 'VoidTypeAnnotation') {
         const ok: ?boolean = maybeIterableAnnotation(rightAnnotation);
         if (ok === false) {
-          throw path.buildCodeFrameError(`Cannot iterate ${humanReadableType(rightAnnotation)}`);
+          throw path.buildCodeFrameError(`Cannot iterate ${humanReadableType(rightAnnotation)}.`);
         }
       }
       let id: ?Identifier;
@@ -534,7 +564,7 @@ export default function ({types: t, template}): Object {
         check: checks.iterable({input: id}),
         message: t.binaryExpression(
           '+',
-          t.stringLiteral(`Expected ${generate(right.node).code} to be iterable, got `),
+          t.stringLiteral(`Expected ${humanReadableType(right.node)} to be iterable, got `),
           readableName({inspect: context.inspect, input: id})
         )
       }));
@@ -545,7 +575,13 @@ export default function ({types: t, template}): Object {
 
       const annotation: TypeAnnotation = rightAnnotation.typeParameters.params[0];
       if (compareAnnotations(annotation, leftAnnotation) === false) {
-        throw path.buildCodeFrameError(`Invalid iterator type, expected ${humanReadableType(annotation)} got ${humanReadableType(leftAnnotation)}`);
+        throw path.buildCodeFrameError(
+          buildErrorMessage(
+            `Invalid iterator type.`,
+            annotation,
+            leftAnnotation
+          )
+        );
       }
     }
   };
@@ -578,7 +614,46 @@ export default function ({types: t, template}): Object {
           const body = path.get('body');
           body[body.length - 1].insertAfter(template(`
             function id (input) {
-              return input === null ? 'null' : typeof input === 'object' && input.constructor ? input.constructor.name || '[Unknown Object]' : typeof input;
+              if (input === null) {
+                return 'null';
+              }
+              else if (input === undefined) {
+                return 'undefined';
+              }
+              else if (typeof input === 'string') {
+                return JSON.stringify(input.length > 32 ? input.slice(0, 32) + '...' : input);
+              }
+              else if (typeof input === 'number' || typeof input === 'boolean') {
+                return input + '';
+              }
+              else if (Array.isArray(input)) {
+                if (input.length > 8) {
+                  return '[\\n' + input.map(id).join(',\\n  ') + '\\n]';
+                }
+                else {
+                  return '[' + input.map(id).join(', ') + ']';
+                }
+              }
+              else {
+                var keys = Object.keys(input);
+                if (!keys.length) {
+                  if (input.constructor && input.constructor.name && input.constructor.name !== 'Object') {
+                    return input.constructor.name;
+                  }
+                  else {
+                    return 'Object';
+                  }
+                }
+                var entries = keys.map(key => {
+                  return JSON.stringify(key) + ': ' + id(input[key]);
+                }).join(',\\n  ');
+                if (input.constructor && input.constructor.name && input.constructor.name !== 'Object') {
+                  return input.constructor.name + ' {\\n  ' + entries + '\\n}';
+                }
+                else {
+                  return '{\\n  ' + entries + '\\n}';
+                }
+              }
             }
           `)({id: inspect}));
         }
@@ -690,6 +765,15 @@ export default function ({types: t, template}): Object {
     return annotation.type === 'GenericTypeAnnotation' && annotation.id.name === 'Generator';
   }
 
+  function buildErrorMessage (message: string, expected: TypeAnnotation, got: ?Node) {
+    if (got) {
+      return message + '\nExpected:\n' + humanReadableType(expected) + '\n\nGot:\n' + humanReadableType(got);
+    }
+    else {
+      return message + '\nExpected:\n' + humanReadableType(expected);
+    }
+  }
+
   function createChecks (): Object {
     return {
       number: expression(`typeof input === 'number'`),
@@ -726,7 +810,9 @@ export default function ({types: t, template}): Object {
       int32: expression(`typeof input === 'number' && !isNaN(input) && input >= -2147483648 && input <= 2147483647 && input === Math.floor(input)`),
       uint32: expression(`typeof input === 'number' && !isNaN(input) && input >= 0 && input <= 4294967295 && input === Math.floor(input)`),
       float32: expression(`typeof input === 'number' && !isNaN(input) && input >= -3.40282347e+38 && input <= 3.40282347e+38`),
-      float64: expression(`typeof input === 'number' && !isNaN(input)`)
+      float64: expression(`typeof input === 'number' && !isNaN(input)`),
+      double: expression(`typeof input === 'number' && !isNaN(input)`)
+
 
     };
   }
@@ -774,6 +860,9 @@ export default function ({types: t, template}): Object {
           return null;
         }
         else if (type.name === 'float64' && !scope.hasBinding('float64')) {
+          return null;
+        }
+        else if (type.name === 'double' && !scope.hasBinding('double')) {
           return null;
         }
         return maybeInstanceOfAnnotation(getAnnotation(path), type, annotation.typeParameters ? annotation.typeParameters.params : []);
@@ -1293,7 +1382,7 @@ export default function ({types: t, template}): Object {
       return checkObjectPattern({input, properties, scope});
     }
     const propNames = [];
-    const check = properties.reduce((expr, prop, index) => {
+    const check = properties.length === 0 ? checkIsObject({input}) : properties.reduce((expr, prop, index) => {
       const target = prop.key.type === 'Identifier' ? t.memberExpression(input, prop.key) : t.memberExpression(input, prop.key, true);
       propNames.push(prop.key.type === 'Identifier' ? t.stringLiteral(prop.key.name) : prop.key);
       let check = checkAnnotation(target, prop.value, scope);
@@ -1314,7 +1403,7 @@ export default function ({types: t, template}): Object {
       else {
         return expr;
       }
-    }, checkIsObject({input}));
+    }, checkNotNull({input}));
 
     if (indexers.length) {
       return indexers.reduceRight((expr, indexer) => {
@@ -1456,6 +1545,9 @@ export default function ({types: t, template}): Object {
         }
         else if (annotation.id.name === 'float64' && !scope.hasBinding('float64')) {
           return checks.float64({input});
+        }
+        else if (annotation.id.name === 'double' && !scope.hasBinding('double')) {
+          return checks.double({input});
         }
         else if (annotation.id.name === 'Symbol' && !scope.hasBinding('Symbol')) {
           return checks.symbol({input});
@@ -2031,16 +2123,18 @@ export default function ({types: t, template}): Object {
   }
 
   /**
-   * Returns `true` if the annotation is definitely for an array,
-   * otherwise `false`.
+   * Determine whether the given annotation is for an array.
    */
-  function isStrictlyArrayAnnotation (annotation: TypeAnnotation): boolean {
+  function isStrictlyArrayAnnotation (annotation: TypeAnnotation): ?boolean {
     switch (annotation.type) {
+      case 'ArrayTypeAnnotation':
+      case 'TupleTypeAnnotation':
+        return true;
       case 'TypeAnnotation':
       case 'FunctionTypeParam':
         return isStrictlyArrayAnnotation(annotation.typeAnnotation);
       case 'GenericTypeAnnotation':
-        return annotation.id.name === 'Array';
+        return annotation.id.name === 'Array' ? true : null;
       case 'UnionTypeAnnotation':
         return annotation.types.every(isStrictlyArrayAnnotation);
       default:
@@ -2474,7 +2568,7 @@ export default function ({types: t, template}): Object {
     }
   }
 
- /**
+  /**
    * Returns `true` if the annotation is compatible with an iterable,
    * `false` if it definitely isn't, or `null` if we're not sure.
    */
@@ -2557,7 +2651,7 @@ export default function ({types: t, template}): Object {
     }
   }
 
-  function humanReadableType (annotation: TypeAnnotation): string {
+  function humanReadableType (annotation: Node|TypeAnnotation): string {
     switch (annotation.type) {
       case 'TypeAnnotation':
       case 'FunctionTypeParam':
@@ -2566,8 +2660,29 @@ export default function ({types: t, template}): Object {
       case 'FunctionTypeAnnotation':
         // @fixme babel doesn't seem to like generating FunctionTypeAnnotations yet
         return `(${annotation.params.map(humanReadableType).join(', ')}) => ${humanReadableType(annotation.returnType)}`;
+      case 'GenericTypeAnnotation':
+        const path = getNodePath(annotation);
+        const checker = path && getTypeChecker(annotation.id, path.scope);
+        if (checker && checker.node.savedTypeAnnotation) {
+          return humanReadableType(checker.node.savedTypeAnnotation);
+        }
+        else {
+          return generate(annotation).code;
+        }
       default:
         return generate(annotation).code;
+    }
+  }
+
+  /**
+   * Get the path directly from a node.
+   */
+  function getNodePath (node: Node): ?NodePath {
+    if (node._paths && node._paths.length) {
+      return node._paths[0];
+    }
+    else {
+      return null;
     }
   }
 
@@ -2702,7 +2817,13 @@ export default function ({types: t, template}): Object {
     const {left: id, right: value} = node;
     const ok = staticCheckAnnotation(path.get('right'), id.typeAnnotation);
     if (ok === false) {
-      throw path.buildCodeFrameError(`Invalid default value for argument "${id.name}", expected ${humanReadableType(id.typeAnnotation)}.`);
+      throw path.buildCodeFrameError(
+        buildErrorMessage(
+          `Invalid default value for argument "${id.name}".`,
+          id.typeAnnotation,
+          getAnnotation(path.get('right'))
+        )
+      );
     }
     return createParamGuard(path.get('left'), context);
   }
@@ -2712,8 +2833,14 @@ export default function ({types: t, template}): Object {
     const {argument: id} = node;
     id.hasBeenTypeChecked = true;
     node.savedTypeAnnotation = node.typeAnnotation;
-    if (!isStrictlyArrayAnnotation(node.typeAnnotation)) {
-      throw path.buildCodeFrameError(`Invalid type annotation for rest argument "${id.name}", expected an Array, got: ${humanReadableType(node.typeAnnotation)}.`);
+    if (isStrictlyArrayAnnotation(node.typeAnnotation) === false) {
+      throw path.buildCodeFrameError(
+        buildErrorMessage(
+          `Invalid type annotation for rest argument "${id.name}".`,
+          t.genericTypeAnnotation(t.identifier('Array')),
+          node.typeAnnotation
+        )
+      );
     }
     let check = checkAnnotation(id, node.typeAnnotation, scope);
     if (!check) {
@@ -2743,7 +2870,7 @@ export default function ({types: t, template}): Object {
     if (fn.generator && isGeneratorAnnotation(annotation) && annotation.typeParameters && annotation.typeParameters.params.length > 1) {
       annotation = annotation.typeParameters.params[1];
     }
-    const message = `Function ${name ? `"${name}" ` : ''}return value violates contract, expected ${humanReadableType(annotation)} got `;
+    const message = `Function ${name ? `"${name}" ` : ''}return value violates contract.\n\nExpected:\n${humanReadableType(annotation)}\n\nGot:\n`;
 
     return t.binaryExpression(
       '+',
@@ -2754,7 +2881,7 @@ export default function ({types: t, template}): Object {
 
   function yieldTypeErrorMessage (fn: Node, annotation: TypeAnnotation, id: Identifier|Literal, context: VisitorContext): Node {
     const name = fn.id ? fn.id.name : '';
-    const message = `Function ${name ? `"${name}" ` : ''} yielded an invalid value, expected ${humanReadableType(annotation)} got `;
+    const message = `Function ${name ? `"${name}" ` : ''}yielded an invalid value.\n\nExpected:\n${humanReadableType(annotation)}\n\nGot:\n`;
 
     return t.binaryExpression(
       '+',
@@ -2764,7 +2891,7 @@ export default function ({types: t, template}): Object {
   }
   function yieldNextTypeErrorMessage (fn: Node, annotation: TypeAnnotation, id: Identifier|Literal, context: VisitorContext): Node {
     const name = fn.id ? fn.id.name : '';
-    const message = `Generator ${name ? `"${name}" ` : ''}received an invalid next value, expected ${humanReadableType(annotation)} got `;
+    const message = `Generator ${name ? `"${name}" ` : ''}received an invalid next value.\n\nExpected:\n${humanReadableType(annotation)}\n\nGot:\n`;
 
     return t.binaryExpression(
       '+',
@@ -2775,7 +2902,7 @@ export default function ({types: t, template}): Object {
 
   function paramTypeErrorMessage (node: Node, context: VisitorContext, typeAnnotation: TypeAnnotation = node.typeAnnotation): Node {
     const name = node.name;
-    const message = `Value of ${node.optional ? 'optional ' : ''}argument "${name}" violates contract, expected ${humanReadableType(typeAnnotation)} got `;
+    const message = `Value of ${node.optional ? 'optional ' : ''}argument "${name}" violates contract.\n\nExpected:\n${humanReadableType(typeAnnotation)}\n\nGot:\n`;
 
     return t.binaryExpression(
       '+',
@@ -2788,7 +2915,7 @@ export default function ({types: t, template}): Object {
     const annotation: TypeAnnotation = node.typeAnnotation;
     if (node.type === 'Identifier') {
       const name = node.name;
-      const message = `Value of variable "${name}" violates contract, expected ${humanReadableType(annotation)} got `;
+      const message = `Value of variable "${name}" violates contract.\n\nExpected:\n${humanReadableType(annotation)}\n\nGot:\n`;
       return t.binaryExpression(
         '+',
         t.stringLiteral(message),
@@ -2796,7 +2923,7 @@ export default function ({types: t, template}): Object {
       );
     }
     else {
-      const message = `Value of "${generate(node).code}" violates contract, expected ${humanReadableType(annotation)} got `;
+      const message = `Value of "${humanReadableType(node)}" violates contract.\n\nExpected:\n${humanReadableType(annotation)}\n\nGot:\n`;
       return t.binaryExpression(
         '+',
         t.stringLiteral(message),

--- a/src/index.js
+++ b/src/index.js
@@ -618,7 +618,7 @@ export default function ({types: t, template}): Object {
                 return 'null';
               }
               else if (input === undefined) {
-                return 'undefined';
+                return 'void';
               }
               else if (typeof input === 'string' || typeof input === 'number' || typeof input === 'boolean') {
                 return typeof input;
@@ -1650,7 +1650,6 @@ export default function ({types: t, template}): Object {
       return t.voidTypeAnnotation();
     }
     const {node, scope} = path;
-
     if (node.type === 'TypeAlias') {
       return node.right;
     }
@@ -2794,10 +2793,14 @@ export default function ({types: t, template}): Object {
 
     node.hasBeenTypeChecked = true;
     node.savedTypeAnnotation = node.typeAnnotation;
+    let check;
     if (node.type === 'ObjectPattern') {
-      return;
+      node.name = path.key;
+      check = checkAnnotation(t.memberExpression(t.identifier('arguments'), t.numericLiteral(path.key), true), node.typeAnnotation, scope);
     }
-    let check = checkAnnotation(node, node.typeAnnotation, scope);
+    else {
+      check = checkAnnotation(node, node.typeAnnotation, scope);
+    }
     if (!check) {
       return;
     }
@@ -2905,7 +2908,7 @@ export default function ({types: t, template}): Object {
 
   function paramTypeErrorMessage (node: Node, context: VisitorContext, typeAnnotation: TypeAnnotation = node.typeAnnotation): Node {
     const name = node.name;
-    const message = `Value of ${node.optional ? 'optional ' : ''}argument "${name}" violates contract.\n\nExpected:\n${humanReadableType(typeAnnotation)}\n\nGot:\n`;
+    const message = `Value of ${node.optional ? 'optional ' : ''}argument ${JSON.stringify(name)} violates contract.\n\nExpected:\n${humanReadableType(typeAnnotation)}\n\nGot:\n`;
 
     return t.binaryExpression(
       '+',

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export default function ({types: t, template}): Object {
   const checkIsSet: (() => Node) = expression(`input instanceof Set`);
   const checkIsClass: (() => Node) = expression(`typeof input === 'function' && input.prototype && input.prototype.constructor === input`);
   const checkIsGenerator: (() => Node) = expression(`typeof input === 'function' && input.generator`);
-  const checkIsIterable: (() => Node) = expression(`input && typeof input[Symbol.iterator] === 'function'`);
+  const checkIsIterable: (() => Node) = expression(`input && (typeof input[Symbol.iterator] === 'function' || Array.isArray(input))`);
   const checkIsObject: (() => Node) = expression(`input != null && typeof input === 'object'`);
   const checkNotNull: (() => Node) = expression(`input != null`);
   const checkEquals: (() => Node) = expression(`input === expected`);
@@ -770,10 +770,10 @@ export default function ({types: t, template}): Object {
 
   function buildErrorMessage (message: string, expected: TypeAnnotation, got: ?Node) {
     if (got) {
-      return message + '\nExpected:\n' + humanReadableType(expected) + '\n\nGot:\n' + humanReadableType(got);
+      return message + '\n\nExpected:\n' + humanReadableType(expected) + '\n\nGot:\n' + humanReadableType(got);
     }
     else {
-      return message + '\nExpected:\n' + humanReadableType(expected);
+      return message + '\n\nExpected:\n' + humanReadableType(expected);
     }
   }
 

--- a/test/fixtures/bug-96-iterate-array.js
+++ b/test/fixtures/bug-96-iterate-array.js
@@ -1,0 +1,4 @@
+export default function demo () {
+  const strategies = [];
+  for (const strategy of strategies) {}
+}

--- a/test/fixtures/rest-params-array.js
+++ b/test/fixtures/rest-params-array.js
@@ -1,8 +1,8 @@
-export default function countArgs(...args: number[]): number {
+export default function countArgs(...args: Array<number>): number {
 	return args.length;
 }
 
-export default function countArgs2(...args2: number[]|string[]): number {
+export default function countArgs2(...args2: Array<number>|Array<string>): number {
 	return args2.length;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,100 +13,354 @@ else {
 
 describe('Typecheck', function () {
   ok('object-indexer-basic', 'foo', 'bar');
-  failWith(`Function "demo" return value violates contract, expected Thing got Object`, 'object-indexer-basic', 'foo', false);
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    {
+      [key: string]: string | number
+    }
+
+    Got:
+    {
+      "string": "hello world",
+      "number": 123,
+      "foo": false
+    }
+  `, 'object-indexer-basic', 'foo', false);
 
   ok('object-indexer-mixed', 'foo', 'bar');
   ok('object-indexer-mixed', 'foo', 123);
-  failWith(`Function "demo" return value violates contract, expected Thing got Object`, 'object-indexer-mixed', 'foo', false);
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    { bool: bool;
+      bools: bool[];
+      [key: string]: string | number;
+    }
+
+    Got:
+    {
+      "bool": true,
+      "bools": [true, false],
+      "string": "hello world",
+      "number": 123,
+      "foo": false
+    }`, 'object-indexer-mixed', 'foo', false);
 
   ok('int8', 0);
   ok('int8', 1);
   ok('int8', 12);
   ok('int8', 126);
   ok('int8', -127);
-  failWith(`Value of argument "input" violates contract, expected int8 got number`,'int8', 128);
-  failWith(`Value of argument "input" violates contract, expected int8 got number`,'int8', -129);
-  failWith(`Value of argument "input" violates contract, expected int8 got number`,'int8', 123.45);
-  failWith(`Value of argument "input" violates contract, expected int8 got string`, 'int8', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int8
+
+    Got:
+    128`,'int8', 128);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int8
+
+    Got:
+    -129`,'int8', -129);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int8
+
+    Got:
+    123.45`,'int8', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int8
+
+    Got:
+    "nope"`, 'int8', 'nope');
 
   ok('uint8', 0);
   ok('uint8', 1);
   ok('uint8', 2);
   ok('uint8', 25);
   ok('uint8', 254);
-  failWith(`Value of argument "input" violates contract, expected uint8 got number`,'uint8', 256);
-  failWith(`Value of argument "input" violates contract, expected uint8 got number`,'uint8', -1);
-  failWith(`Value of argument "input" violates contract, expected uint8 got number`,'uint8', 123.45);
-  failWith(`Value of argument "input" violates contract, expected uint8 got string`, 'uint8', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint8
+
+    Got:
+    256`,'uint8', 256);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint8
+
+    Got:
+    -1`,'uint8', -1);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint8
+
+    Got:
+    123.45`,'uint8', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint8
+
+    Got:
+    "nope"`, 'uint8', 'nope');
 
   ok('int16', 0);
   ok('int16', 3);
   ok('int16', 32);
   ok('int16', 327);
   ok('int16', 32766)
-  failWith(`Value of argument "input" violates contract, expected int16 got number`,'int16', 32768);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int16
+
+    Got:
+    32768`,'int16', 32768);
   ok('int16', -32768);
-  failWith(`Value of argument "input" violates contract, expected int16 got number`,'int16', -32769);
-  failWith(`Value of argument "input" violates contract, expected int16 got number`,'int16', 123.45);
-  failWith(`Value of argument "input" violates contract, expected int16 got string`, 'int16', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int16
+
+    Got:
+    -32769`,'int16', -32769);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int16
+
+    Got:
+    123.45`,'int16', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int16
+
+    Got:
+    "nope"`, 'int16', 'nope');
 
   ok('uint16', 0);
   ok('uint16', 6);
   ok('uint16', 65);
   ok('uint16', 655);
   ok('uint16', 65534);
-  failWith(`Value of argument "input" violates contract, expected uint16 got number`,'uint16', 65536);
-  failWith(`Value of argument "input" violates contract, expected uint16 got number`,'uint16', -1);
-  failWith(`Value of argument "input" violates contract, expected uint16 got number`,'uint16', 123.45);
-  failWith(`Value of argument "input" violates contract, expected uint16 got string`, 'uint16', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint16
+
+    Got:
+    65536`,'uint16', 65536);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint16
+
+    Got:
+    -1`,'uint16', -1);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint16
+
+    Got:
+    123.45`,'uint16', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint16
+
+    Got:
+    "nope"`, 'uint16', 'nope');
 
   ok('int32', 0);
   ok('int32', 3);
   ok('int32', 32);
   ok('int32', 327);
   ok('int32', 2147483646)
-  failWith(`Value of argument "input" violates contract, expected int32 got number`,'int32', 2147483648);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int32
+
+    Got:
+    2147483648`,'int32', 2147483648);
   ok('int32', -2147483648);
-  failWith(`Value of argument "input" violates contract, expected int32 got number`,'int32', -2147483649);
-  failWith(`Value of argument "input" violates contract, expected int32 got number`,'int32', 123.45);
-  failWith(`Value of argument "input" violates contract, expected int32 got string`, 'int32', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int32
+
+    Got:
+    -2147483649`,'int32', -2147483649);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int32
+
+    Got:
+    123.45`,'int32', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    int32
+
+    Got:
+    "nope"`, 'int32', 'nope');
 
   ok('uint32', 0);
   ok('uint32', 6);
   ok('uint32', 65);
   ok('uint32', 655);
   ok('uint32', 4294967294);
-  failWith(`Value of argument "input" violates contract, expected uint32 got number`,'uint32', 4294967296);
-  failWith(`Value of argument "input" violates contract, expected uint32 got number`,'uint32', -1);
-  failWith(`Value of argument "input" violates contract, expected uint32 got number`,'uint32', 123.45);
-  failWith(`Value of argument "input" violates contract, expected uint32 got string`, 'uint32', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint32
+
+    Got:
+    4294967296`,'uint32', 4294967296);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint32
+
+    Got:
+    -1`,'uint32', -1);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint32
+
+    Got:
+    123.45`,'uint32', 123.45);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    uint32
+
+    Got:
+    "nope"`, 'uint32', 'nope');
 
   ok('float32', 1.999);
   ok('float32', -1.999);
   ok('float32', 1e5);
-  failWith(`Value of argument "input" violates contract, expected float32 got number`, 'float32', -3.40282348e+38);
-  failWith(`Value of argument "input" violates contract, expected float32 got number`, 'float32', 3.40282348e+38);
-  failWith(`Value of argument "input" violates contract, expected float32 got number`, 'float32', 1e48);
-  failWith(`Value of argument "input" violates contract, expected float32 got string`, 'float32', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    float32
+
+    Got:
+    -3.40282348e+38`, 'float32', -3.40282348e+38);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    float32
+
+    Got:
+    3.40282348e+38`, 'float32', 3.40282348e+38);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    float32
+
+    Got:
+    1e+48`, 'float32', 1e48);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    float32
+
+    Got:
+    "nope"`, 'float32', 'nope');
 
   ok('float64', 123);
   ok('float64', -123);
   ok('float64', Math.pow(2, 32));
   ok('float64', Math.pow(2, 48));
   ok('float64', Math.pow(2, 53));
-  failWith(`Value of argument "input" violates contract, expected float64 got string`, 'float64', 'nope');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    float64
+
+    Got:
+    "nope"`, 'float64', 'nope');
 
 
   ok('bug-87-bad-check', {});
   ok('class-annotation', class Thing {});
-  failWith(`Value of argument "input" violates contract, expected Class got boolean`, 'class-annotation', false);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    Class
+
+    Got:
+    false`, 'class-annotation', false);
 
   if (!(() => true).prototype) {
-    failWith(`Value of argument "input" violates contract, expected Class got function`, 'class-annotation', () => true);
+    failWith(`
+      Value of argument "input" violates contract.
+
+      Expected:
+      Class
+
+      Got:
+      function`, 'class-annotation', () => true);
   }
   else {
     // environment does not support spec compliant arrow functions.
-    it.skip(`Value of argument "input" violates contract, expected Class got function`);
+    it.skip(`
+      Value of argument "input" violates contract.
+
+      Expected:
+      Class
+
+      Got:
+      function`);
   }
 
   ok('bug-83-spread-object', {a: 1, b: 2, c: 3});
@@ -116,7 +370,14 @@ describe('Typecheck', function () {
   ok('bug-76-cannot-read-property-name-of-undefined');
   ok('bug-71-cannot-iterate-void');
   ok('iterable', [1, 2, 3]);
-  failWith(`Value of variable "item" violates contract, expected number got string`, 'iterable', ['a', 'b', 'c']);
+  failWith(`
+    Value of variable "item" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    "a"`, 'iterable', ['a', 'b', 'c']);
   failStatic('bad-iterable', [1, 2, 3]);
   failStatic('bad-iterable-type', 123);
 
@@ -125,10 +386,31 @@ describe('Typecheck', function () {
   ok('object-pattern', {a: 'foo', b: 34});
   ok('object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: false, a: 123}});
   ok('generators', 'foo');
-  failWith(`Function "gen"  yielded an invalid value, expected number | string got boolean`, 'generators', false);
+  failWith(`
+    Function "gen" yielded an invalid value.
+
+    Expected:
+    number | string
+
+    Got:
+    false`, 'generators', false);
   ok('generators-with-next', 12);
-  failWith(`Generator "gen" received an invalid next value, expected number got string`, 'generators-with-next', 'foo');
-  failWith(`Generator "gen" received an invalid next value, expected number got boolean`, 'generators-with-next', false);
+  failWith(`
+    Generator "gen" received an invalid next value.
+
+    Expected:
+    number
+
+    Got:
+    "foo"`, 'generators-with-next', 'foo');
+  failWith(`
+    Generator "gen" received an invalid next value.
+
+    Expected:
+    number
+
+    Got:
+    false`, 'generators-with-next', false);
   failStatic('bad-generators', 'foo');
   failStatic('bad-generators-return', 'foo');
   ok('object-properties-function', 'bob', 'bob@example.com');
@@ -136,34 +418,92 @@ describe('Typecheck', function () {
   ok('bug-62-default-params', {option1: 'foo'});
   ok('bug-62-default-params', {option1: 'foo', option2: false});
   ok('bug-62-default-params', {option1: 'foo', option2: true, option3: 123});
-  failWith(`Value of optional argument "options" violates contract, expected { option1?: string;
-    option2?: bool;
-    option3?: number;
-  } got Object`, 'bug-62-default-params', {option1: true});
-  failWith(`Value of optional argument "options" violates contract, expected { option1?: string;
-    option2?: bool;
-    option3?: number;
-  } got Object`, 'bug-62-default-params', {option1: 'foo', option2: 'nope'});
-  failWith(`Value of optional argument "options" violates contract, expected { option1?: string;
-    option2?: bool;
-    option3?: number;
-  } got Object`, 'bug-62-default-params', {option1: 'foo', option2: true, option3: 'nope'});
+  failWith(`
+    Value of optional argument "options" violates contract.
+
+    Expected:
+    { option1?: string;
+      option2?: bool;
+      option3?: number;
+    }
+
+    Got:
+    {
+      "option1": true
+    }`, 'bug-62-default-params', {option1: true});
+  failWith(`
+    Value of optional argument "options" violates contract.
+
+    Expected:
+    { option1?: string;
+      option2?: bool;
+      option3?: number;
+    }
+
+    Got:
+    {
+      "option1": "foo",
+      "option2": "nope"
+    }`, 'bug-62-default-params', {option1: 'foo', option2: 'nope'});
+  failWith(`
+    Value of optional argument "options" violates contract.
+
+    Expected:
+    { option1?: string;
+      option2?: bool;
+      option3?: number;
+    }
+
+    Got:
+    {
+      "option1": "foo",
+      "option2": true,
+      "option3": "nope"
+    }`, 'bug-62-default-params', {option1: 'foo', option2: true, option3: 'nope'});
   ok('bug-xxx-method-params');
   ok('bug-59-type-annotation-in-loop', 'foo');
   ok('bug-59-type-annotation-in-loop-again', 'foo');
   ok('object-method', 'bob', 'bob@example.com');
   failStatic('bad-object-method', 'bob', 'bob@example.com');
   failStatic('bad-object-method-arrow', 'bob', 'bob@example.com');
-  failWith(`Value of "this.name" violates contract, expected string got boolean`, 'object-method', false, 'bob@example.com');
+  failWith(`
+    Value of "this.name" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    false`, 'object-method', false, 'bob@example.com');
   ok('object-properties', 'bob', 'bob@example.com');
   failStatic('bad-object-properties', 'bob', 'bob@example.com');
-  failWith(`Value of "user.name" violates contract, expected string got boolean`, 'object-properties', false, 'bob@example.com');
-  failWith(`Value of "user.email" violates contract, expected string got boolean`, 'object-properties', 'bob', false);
+  failWith(`
+    Value of "user.name" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    false`, 'object-properties', false, 'bob@example.com');
+  failWith(`
+    Value of "user.email" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    false`, 'object-properties', 'bob', false);
   ok('class-getter', 'alice');
   failStatic('bad-class-getter', 'alice');
   ok('class-setter', 'alice');
   failStatic('bad-class-setter', 'alice');
-  failWith(`Value of argument "name" violates contract, expected string got number`, 'class-setter', 123);
+  failWith(`
+    Value of argument "name" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    123`, 'class-setter', 123);
   ok('class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
@@ -173,7 +513,14 @@ describe('Typecheck', function () {
     }
   }, 'FR');
 
-  failWith(`Value of "user.location.country" violates contract, expected CountryCode got string`, 'class-properties-complex', 'sally', 'bob@example.com', {
+  failWith(`
+    Value of "user.location.country" violates contract.
+
+    Expected:
+    "GB" | "US" | "FR" | "CA"
+
+    Got:
+    "Invalid"`, 'class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
     pos: {
@@ -182,7 +529,14 @@ describe('Typecheck', function () {
     }
   }, 'Invalid');
 
-  failWith(`Value of "user.location.country" violates contract, expected CountryCode got boolean`, 'class-properties-complex', 'sally', 'bob@example.com', {
+  failWith(`
+    Value of "user.location.country" violates contract.
+
+    Expected:
+    "GB" | "US" | "FR" | "CA"
+
+    Got:
+    false`, 'class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
     pos: {
@@ -191,56 +545,159 @@ describe('Typecheck', function () {
     }
   }, false);
   ok('class-properties', 'bob', 'bob@example.com');
-  failWith(`Value of "this.email" violates contract, expected string got null`, 'class-properties', 'bob', null);
-  failWith(`Value of "this.name" violates contract, expected string got boolean`, 'class-properties', false, 'bob@example.com');
+  failWith(`
+    Value of "this.email" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    null`, 'class-properties', 'bob', null);
+  failWith(`
+    Value of "this.name" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    false`, 'class-properties', false, 'bob@example.com');
   ok('string-literal-annotations', 'foo');
   ok('string-literal-annotations', 'bar');
-  failWith(`Value of argument "input" violates contract, expected "foo" | "bar" got string`, 'string-literal-annotations', 'wat');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    "foo" | "bar"
+
+    Got:
+    "wat"`, 'string-literal-annotations', 'wat');
   failStatic('bad-string-literal-annotations', 'foo');
 
   ok('boolean-literal-annotations', true);
   ok('boolean-literal-annotations', false);
-  failWith(`Value of argument "input" violates contract, expected true | false got string`, 'boolean-literal-annotations', 'wat');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    true | false
+
+    Got:
+    "wat"`, 'boolean-literal-annotations', 'wat');
 
   ok('numeric-literal-annotations', 1);
   ok('numeric-literal-annotations', 2);
-  failWith(`Value of argument "input" violates contract, expected 1 | 2 got number`, 'numeric-literal-annotations', 3);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    1 | 2
+
+    Got:
+    3`, 'numeric-literal-annotations', 3);
 
   ok('enum', 'active');
   ok('enum', 'inactive');
-  failWith(`Value of argument "input" violates contract, expected status got string`, 'enum', 'pending');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    "active" | "inactive"
+
+    Got:
+    "pending"`, 'enum', 'pending');
 
   ok('pragma-ignore-statement', 'some string');
   ok('pragma-ignore-file', 'some string');
 
   ok('async-method', ['hello world']);
   ok('async-function', ['hello world']);
-  failWith(`Value of argument "input" violates contract, expected string[] got Array`, 'async-function', [123]);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    string[]
+
+    Got:
+    [123]`, 'async-function', [123]);
   failStatic('bad-async-function', 'hello world');
   ok('class-getter', 'alice');
   ok("bug-xxx-export");
   ok('new', 'bob');
   ok('symbols', Symbol('foo'));
-  failWith(`Value of argument "input" violates contract, expected Symbol got string`, 'symbols', 'wat');
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    Symbol
+
+    Got:
+    "wat"`, 'symbols', 'wat');
   ok('export-typed-var', 'foo');
   ok('bug-48-export-star', 'wat');
   ok('typeof', {name: 'bob'});
-  failWith('Value of argument "input" violates contract, expected typeof user got Object', 'typeof', {name: false});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    typeof user
+
+    Got:
+    {
+      "name": false
+    }`, 'typeof', {name: false});
   ok('typeof-class', 'bob');
-  failWith('Function "demo" return value violates contract, expected typeof user got string', 'typeof-class', false);
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    typeof user
+
+    Got:
+    "nope"`, 'typeof-class', false);
 
   ok('intersection', {name: 'bob', address: '123 Fake Street'});
-  failWith('Value of argument "input" violates contract, expected Nameable & Locatable got Object', 'intersection', {name: 'bob', address: false});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    Nameable & Locatable
+
+    Got:
+    {
+      "name": "bob",
+      "address": false
+    }`, 'intersection', {name: 'bob', address: false});
 
   ok('set-entries', new Set([1, 2, 3]));
-  failWith('Value of argument "input" violates contract, expected Set<number> got Set', 'set-entries', new Set([1, 'b', 3]));
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    Set<number>
+
+    Got:
+    Set`, 'set-entries', new Set([1, 'b', 3]));
 
   ok('map-keys', new Map([['a', 1], ['b', 2], ['c', 3]]));
   ok('map-values', new Map([['a', 1], ['b', 2], ['c', 3]]));
-  failWith(`Function "demo" return value violates contract, expected Map<*, number> got Map`, 'bad-map-values', new Map([['a', 1], ['b', 2], ['c', 3]]));
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    Map<*, number>
+
+    Got:
+    Map`, 'bad-map-values', new Map([['a', 1], ['b', 2], ['c', 3]]));
 
   ok('map-contents', new Map([['a', 1], ['b', 2], ['c', 3]]));
-  failWith('Value of argument "input" violates contract, expected Map<string, number> got Map', 'map-contents', new Map([['a', 1], ['b', 2], ['c', 'nope']]));
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    Map<string, number>
+
+    Got:
+    Map`, 'map-contents', new Map([['a', 1], ['b', 2], ['c', 'nope']]));
   ok('interface', {name: 'hello world'});
   ok('interface-extends', {name: 'hello world', age: 123});
   ok('interface-multi-extends', {name: 'hello world', age: 123, isActive: true});
@@ -249,7 +706,14 @@ describe('Typecheck', function () {
   ok('class-type-params', ['hello world']);
 
   ok('array-type-annotation', ['foo', 'bar']);
-  failWith('Value of argument "input" violates contract, expected string[] got Array', 'array-type-annotation', ['foo', 123]);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    string[]
+
+    Got:
+    ["foo", 123]`, 'array-type-annotation', ['foo', 123]);
 
   ok('infer-member-expression-from-object', {name: "bob"});
   ok('logical-expression', 'foo');
@@ -275,7 +739,16 @@ describe('Typecheck', function () {
 
   failStatic("bad-conditional-return-value");
 
-  failWith("Function \"demo\" return value violates contract, expected number | string got Object", "conditional-return-value", {a: 123});
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    number | string
+
+    Got:
+    {
+      "a": 123
+    }`, "conditional-return-value", {a: 123});
 
 
   ok("assignment-expression", [1, 2, 3]);
@@ -287,17 +760,118 @@ describe('Typecheck', function () {
   ok("generic-function", 123);
   ok("fancy-generic-function", Buffer(123), (value) => value);
   ok("return-object-types", {greeting: "hello world", id: 123});
-  failWith("Function \"demo\" return value violates contract, expected { greeting: string; id: number; } got Object", "return-object-types", {foo: "bar"});
+  failWith(`
+    Function "demo" return value violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+    }
+
+    Got:
+    {
+      "foo": "bar"
+    }`, "return-object-types", {foo: "bar"});
 
   ok("nested-object-types", {greeting: "hello world", id: 123, nested: {left: 10, right: 20}});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; nested: { left: number; right: number; }; } got Object", "nested-object-types", {foo: "bar"});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; nested: { left: number; right: number; }; } got Object", "nested-object-types", {greeting: "hello world", id: 123, nested: {left: true, right: false}});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; nested: { left: number; right: number; }; } got Object", "nested-object-types", {greeting: "hello world", id: 123, nested: {left: 10}});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; nested: { left: number; right: number; }; } got Object", "nested-object-types", {greeting: "hello world", id: "123", nested: {left: 10, right: 20}});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+      nested: { left: number;
+        right: number;
+      };
+    }
+
+    Got:
+    {
+      "foo": "bar"
+    }`, "nested-object-types", {foo: "bar"});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+      nested: { left: number;
+        right: number;
+      };
+    }
+
+    Got:
+    {
+      "greeting": "hello world",
+      "id": 123,
+      "nested": {
+        "left": true, "right": false
+      }
+    }`, "nested-object-types", {greeting: "hello world", id: 123, nested: {left: true, right: false}});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+      nested: { left: number;
+        right: number;
+      };
+    }
+
+    Got:
+    {
+      "greeting": "hello world",
+      "id": 123,
+      "nested": {
+        "left": 10
+      }
+    }`, "nested-object-types", {greeting: "hello world", id: 123, nested: {left: 10}});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+      nested: { left: number;
+        right: number;
+      };
+    }
+
+    Got:
+    {
+      "greeting": "hello world",
+      "id": "123",
+      "nested": {
+      "left": 10,
+      "right": 20
+    }
+    }
+    `, "nested-object-types", {greeting: "hello world", id: "123", nested: {left: 10, right: 20}});
 
   ok("complex-object-types", {greeting: "hello world", id: 123});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; } got Object", "complex-object-types", {foo: "bar"});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id: number; } got string", "complex-object-types", "foo");
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+    }
+
+    Got:
+    {
+      "foo": "bar"
+    }`, "complex-object-types", {foo: "bar"});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id: number;
+    }
+
+    Got:
+    "foo"`, "complex-object-types", "foo");
 
   ok("any-return-value");
   ok("callexpr-return-value");
@@ -309,8 +883,26 @@ describe('Typecheck', function () {
   ok("const-tracking-with-new");
   ok("const-tracking-with-new-extended");
 
-  failWith("Value of argument \"input\" violates contract, expected string got undefined", "string-arguments");
-  failWith("Value of argument \"input\" violates contract, expected string got number", "string-arguments", 123);
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    undefined`,
+    "string-arguments");
+
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    123`,
+    "string-arguments",
+    123);
 
   failStatic("bad-const-tracking");
   failStatic("bad-return-value");
@@ -325,8 +917,22 @@ describe('Typecheck', function () {
 
   ok("poly-args", "hello world", /a/);
   ok("poly-args", ["hello world"], /b/);
-  failWith("Value of argument \"arg\" violates contract, expected string | Array<string> got number", "poly-args", 123);
-  failWith("Value of argument \"fn\" violates contract, expected Function | RegExp got number", "poly-args", "hello", 123);
+  failWith(`
+    Value of argument \"arg\" violates contract.
+
+    Expected:
+    string | Array<string>
+
+    Got:
+    123`, "poly-args", 123);
+  failWith(`
+    Value of argument \"fn\" violates contract.
+
+    Expected:
+    Function | RegExp
+
+    Got:
+    123`, "poly-args", "hello", 123);
 
   ok("bug-7-class-support");
   ok("bug-8-class-support");
@@ -334,45 +940,180 @@ describe('Typecheck', function () {
 
   ok("optional-properties", {greeting: "hello world", id: 123});
   ok("optional-properties", {greeting: "hello world"});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id?: number; } got Object", "optional-properties", {greeting: "hello world", id: "123"});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id?: number; } got Object", "optional-properties", {greeting: "hello world", id: null});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id?: number; } got Object", "optional-properties", {id: 123});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id?: number; } got Object", "optional-properties", {foo: "bar"});
-  failWith("Value of argument \"input\" violates contract, expected { greeting: string; id?: number; } got string", "optional-properties", "foo");
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id?: number;
+    }
+
+    Got:
+    {
+      "greeting": "hello world",
+      "id": "123"
+    }`, "optional-properties", {greeting: "hello world", id: "123"});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id?: number;
+    }
+
+    Got:
+    {
+      "greeting": "hello world",
+      "id": null
+    }`, "optional-properties", {greeting: "hello world", id: null});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id?: number;
+    }
+
+    Got:
+    {
+      "id": 123
+    }`, "optional-properties", {id: 123});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id?: number;
+    }
+
+    Got:
+    {
+      "foo": "bar"
+    }`, "optional-properties", {foo: "bar"});
+  failWith(`
+    Value of argument "input" violates contract.
+
+    Expected:
+    { greeting: string;
+      id?: number;
+    }
+
+    Got:
+    "foo"`, "optional-properties", "foo");
 
   ok("optional-arguments", "hello world");
   ok("optional-arguments", "hello world", 123);
-  failWith("Value of optional argument \"bar\" violates contract, expected number got string", "optional-arguments", "hello world", "123");
-  failWith("Value of optional argument \"bar\" violates contract, expected number got null", "optional-arguments", "hello world", null);
+  failWith(`
+    Value of optional argument "bar" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    "123"`, "optional-arguments", "hello world", "123");
+  failWith(`
+    Value of optional argument "bar" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    null`, "optional-arguments", "hello world", null);
 
   ok("default-arguments", "hello world");
   ok("default-arguments", "hello world", 123);
-  failWith("Value of argument \"bar\" violates contract, expected number got string", "default-arguments", "hello world", "123");
-  failWith("Value of argument \"bar\" violates contract, expected number got null", "default-arguments", "hello world", null);
+  failWith(`
+    Value of argument "bar" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    "123"`, "default-arguments", "hello world", "123");
+  failWith(`
+    Value of argument "bar" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    null`, "default-arguments", "hello world", null);
 
   ok("qualified-types", {})
-  failWith("Value of argument \"foo\" violates contract, expected T.Object | T.Array got string", "qualified-types", "hello")
+  failWith(`
+    Value of argument "foo" violates contract.
+
+    Expected:
+    T.Object | T.Array
+
+    Got:
+    "hello"`, "qualified-types", "hello")
 
   ok("var-declarations", ["abc", "123"])
-  failWith("Value of variable \"a\" violates contract, expected Array got string", "var-declarations", "abc")
-  failWith("Value of variable \"b\" violates contract, expected string got number", "var-declarations", ["abc", 123])
+  failWith(`
+    Value of variable "a" violates contract.
+
+    Expected:
+    Array
+
+    Got:
+    "abc"`, "var-declarations", "abc")
+  failWith(`
+    Value of variable "b" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    123`, "var-declarations", ["abc", 123])
 
   ok("var-declarations-2", ["abc", "123"])
   ok("var-declarations-2", ["abc", "1"])
-  failWith("Value of variable \"a\" violates contract, expected Array got string", "var-declarations-2", "abc")
-  failWith("Value of variable \"b\" violates contract, expected string got number", "var-declarations-2", ["abc", 123])
+  failWith(`
+    Value of variable "a" violates contract.
+
+    Expected:
+    Array
+
+    Got:
+    "abc"`, "var-declarations-2", "abc")
+  failWith(`
+    Value of variable "b" violates contract.
+
+    Expected:
+    string
+
+    Got:
+    123`, "var-declarations-2", ["abc", 123])
 
   ok("arrow-function", 123);
   ok("arrow-function-2", 123);
 
-  failWith("Value of argument \"arg\" violates contract, expected number got string", "arrow-function", "abc")
-  failWith("Value of argument \"arg\" violates contract, expected number got string", "arrow-function-2", "abc")
+  failWith(`
+    Value of argument "arg" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    "abc"`, "arrow-function", "abc")
+  failWith(`
+    Value of argument "arg" violates contract.
+
+    Expected:
+    number
+
+    Got:
+    "abc"`, "arrow-function-2", "abc")
 
   ok("bug-30-conditional-return");
 
   ok("rest-params");
   ok("rest-params", 1);
   ok("rest-params", 10, 20);
+  ok("rest-params-array");
+  ok("rest-params-array", 1);
+  ok("rest-params-array", 10, 20);
   failStatic("bad-rest-params");
   failStatic("bad-rest-params-2");
 
@@ -475,7 +1216,7 @@ function failWith (errorMessage, basename, ...args) {
       throw new Error(`Test '${basename}' should have failed but did not.`);
     }
     // ignore differences in whitespace in comparison.
-    if (message.replace(/\s+/g, ' ') !== errorMessage.replace(/\s+/g, ' ')) {
+    if (message.replace(/\s+/g, '') !== errorMessage.replace(/\s+/g, '')) {
       throw new Error(`Test '${basename}' failed with ${message} instead of ${errorMessage}.`);
     }
   });

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,8 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('bug-96-iterate-array');
+
   ok('object-indexer-basic', 'foo', 'bar');
   failWith(`
     Function "demo" return value violates contract.

--- a/test/index.js
+++ b/test/index.js
@@ -386,7 +386,39 @@ describe('Typecheck', function () {
   ok('bug-68-return-string-literal');
   ok('indexers', foo => null);
   ok('object-pattern', {a: 'foo', b: 34});
-  ok('object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: false, a: 123}});
+  failWith(`
+    Value of argument 0 violates contract.
+
+    Expected:
+    { a: string;
+      b: number;
+    }
+
+    Got:
+    { a: string;
+      b: void;
+    }
+  `, 'object-pattern', {a: 'foo'});
+  ok('object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: 123, a: 123}});
+  failWith(`
+    Value of argument 0 violates contract.
+
+    Expected:
+    { a: string;
+      b: number;
+      d: { e: string;
+        g: number;
+      };
+    }
+
+    Got:
+    { a: string;
+      b: number;
+      d: { e: string;
+        g: boolean;
+      };
+    }
+  `, 'object-pattern-complex', {a: 'foo', b: 34, d: {e: 'bar', g: false, a: 123}});
   ok('generators', 'foo');
   failWith(`
     Function "gen" yielded an invalid value.
@@ -893,7 +925,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    undefined`,
+    void`,
     "string-arguments");
 
   failWith(`

--- a/test/index.js
+++ b/test/index.js
@@ -23,9 +23,9 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "string": "hello world",
-      "number": 123,
-      "foo": false
+      string: string;
+      number: number;
+      foo: boolean;
     }
   `, 'object-indexer-basic', 'foo', false);
 
@@ -42,11 +42,11 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "bool": true,
-      "bools": [true, false],
-      "string": "hello world",
-      "number": 123,
-      "foo": false
+      bool: boolean;
+      bools: boolean[];
+      string: string;
+      number: number;
+      foo: boolean;
     }`, 'object-indexer-mixed', 'foo', false);
 
   ok('int8', 0);
@@ -61,7 +61,7 @@ describe('Typecheck', function () {
     int8
 
     Got:
-    128`,'int8', 128);
+    number`,'int8', 128);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -69,7 +69,7 @@ describe('Typecheck', function () {
     int8
 
     Got:
-    -129`,'int8', -129);
+    number`,'int8', -129);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -77,7 +77,7 @@ describe('Typecheck', function () {
     int8
 
     Got:
-    123.45`,'int8', 123.45);
+    number`,'int8', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -85,7 +85,7 @@ describe('Typecheck', function () {
     int8
 
     Got:
-    "nope"`, 'int8', 'nope');
+    string`, 'int8', 'nope');
 
   ok('uint8', 0);
   ok('uint8', 1);
@@ -99,7 +99,7 @@ describe('Typecheck', function () {
     uint8
 
     Got:
-    256`,'uint8', 256);
+    number`,'uint8', 256);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -107,7 +107,7 @@ describe('Typecheck', function () {
     uint8
 
     Got:
-    -1`,'uint8', -1);
+    number`,'uint8', -1);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -115,7 +115,7 @@ describe('Typecheck', function () {
     uint8
 
     Got:
-    123.45`,'uint8', 123.45);
+    number`,'uint8', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -123,7 +123,7 @@ describe('Typecheck', function () {
     uint8
 
     Got:
-    "nope"`, 'uint8', 'nope');
+    string`, 'uint8', 'nope');
 
   ok('int16', 0);
   ok('int16', 3);
@@ -137,7 +137,7 @@ describe('Typecheck', function () {
     int16
 
     Got:
-    32768`,'int16', 32768);
+    number`,'int16', 32768);
   ok('int16', -32768);
   failWith(`
     Value of argument "input" violates contract.
@@ -146,7 +146,7 @@ describe('Typecheck', function () {
     int16
 
     Got:
-    -32769`,'int16', -32769);
+    number`,'int16', -32769);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -154,7 +154,7 @@ describe('Typecheck', function () {
     int16
 
     Got:
-    123.45`,'int16', 123.45);
+    number`,'int16', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -162,7 +162,7 @@ describe('Typecheck', function () {
     int16
 
     Got:
-    "nope"`, 'int16', 'nope');
+    string`, 'int16', 'nope');
 
   ok('uint16', 0);
   ok('uint16', 6);
@@ -176,7 +176,7 @@ describe('Typecheck', function () {
     uint16
 
     Got:
-    65536`,'uint16', 65536);
+    number`,'uint16', 65536);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -184,7 +184,7 @@ describe('Typecheck', function () {
     uint16
 
     Got:
-    -1`,'uint16', -1);
+    number`,'uint16', -1);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -192,7 +192,7 @@ describe('Typecheck', function () {
     uint16
 
     Got:
-    123.45`,'uint16', 123.45);
+    number`,'uint16', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -200,7 +200,7 @@ describe('Typecheck', function () {
     uint16
 
     Got:
-    "nope"`, 'uint16', 'nope');
+    string`, 'uint16', 'nope');
 
   ok('int32', 0);
   ok('int32', 3);
@@ -214,7 +214,7 @@ describe('Typecheck', function () {
     int32
 
     Got:
-    2147483648`,'int32', 2147483648);
+    number`,'int32', 2147483648);
   ok('int32', -2147483648);
   failWith(`
     Value of argument "input" violates contract.
@@ -223,7 +223,7 @@ describe('Typecheck', function () {
     int32
 
     Got:
-    -2147483649`,'int32', -2147483649);
+    number`,'int32', -2147483649);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -231,7 +231,7 @@ describe('Typecheck', function () {
     int32
 
     Got:
-    123.45`,'int32', 123.45);
+    number`,'int32', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -239,7 +239,7 @@ describe('Typecheck', function () {
     int32
 
     Got:
-    "nope"`, 'int32', 'nope');
+    string`, 'int32', 'nope');
 
   ok('uint32', 0);
   ok('uint32', 6);
@@ -253,7 +253,7 @@ describe('Typecheck', function () {
     uint32
 
     Got:
-    4294967296`,'uint32', 4294967296);
+    number`,'uint32', 4294967296);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -261,7 +261,7 @@ describe('Typecheck', function () {
     uint32
 
     Got:
-    -1`,'uint32', -1);
+    number`,'uint32', -1);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -269,7 +269,7 @@ describe('Typecheck', function () {
     uint32
 
     Got:
-    123.45`,'uint32', 123.45);
+    number`,'uint32', 123.45);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -277,7 +277,7 @@ describe('Typecheck', function () {
     uint32
 
     Got:
-    "nope"`, 'uint32', 'nope');
+    string`, 'uint32', 'nope');
 
   ok('float32', 1.999);
   ok('float32', -1.999);
@@ -289,7 +289,7 @@ describe('Typecheck', function () {
     float32
 
     Got:
-    -3.40282348e+38`, 'float32', -3.40282348e+38);
+    number`, 'float32', -3.40282348e+38);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -297,7 +297,7 @@ describe('Typecheck', function () {
     float32
 
     Got:
-    3.40282348e+38`, 'float32', 3.40282348e+38);
+    number`, 'float32', 3.40282348e+38);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -305,7 +305,7 @@ describe('Typecheck', function () {
     float32
 
     Got:
-    1e+48`, 'float32', 1e48);
+    number`, 'float32', 1e48);
   failWith(`
     Value of argument "input" violates contract.
 
@@ -313,7 +313,7 @@ describe('Typecheck', function () {
     float32
 
     Got:
-    "nope"`, 'float32', 'nope');
+    string`, 'float32', 'nope');
 
   ok('float64', 123);
   ok('float64', -123);
@@ -327,7 +327,7 @@ describe('Typecheck', function () {
     float64
 
     Got:
-    "nope"`, 'float64', 'nope');
+    string`, 'float64', 'nope');
 
 
   ok('bug-87-bad-check', {});
@@ -339,7 +339,7 @@ describe('Typecheck', function () {
     Class
 
     Got:
-    false`, 'class-annotation', false);
+    boolean`, 'class-annotation', false);
 
   if (!(() => true).prototype) {
     failWith(`
@@ -377,7 +377,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "a"`, 'iterable', ['a', 'b', 'c']);
+    string`, 'iterable', ['a', 'b', 'c']);
   failStatic('bad-iterable', [1, 2, 3]);
   failStatic('bad-iterable-type', 123);
 
@@ -393,7 +393,7 @@ describe('Typecheck', function () {
     number | string
 
     Got:
-    false`, 'generators', false);
+    boolean`, 'generators', false);
   ok('generators-with-next', 12);
   failWith(`
     Generator "gen" received an invalid next value.
@@ -402,7 +402,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "foo"`, 'generators-with-next', 'foo');
+    string`, 'generators-with-next', 'foo');
   failWith(`
     Generator "gen" received an invalid next value.
 
@@ -410,7 +410,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    false`, 'generators-with-next', false);
+    boolean`, 'generators-with-next', false);
   failStatic('bad-generators', 'foo');
   failStatic('bad-generators-return', 'foo');
   ok('object-properties-function', 'bob', 'bob@example.com');
@@ -429,7 +429,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "option1": true
+      option1: boolean;
     }`, 'bug-62-default-params', {option1: true});
   failWith(`
     Value of optional argument "options" violates contract.
@@ -442,8 +442,8 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "option1": "foo",
-      "option2": "nope"
+      option1: string;
+      option2: string;
     }`, 'bug-62-default-params', {option1: 'foo', option2: 'nope'});
   failWith(`
     Value of optional argument "options" violates contract.
@@ -456,9 +456,9 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "option1": "foo",
-      "option2": true,
-      "option3": "nope"
+      option1: string;
+      option2: boolean;
+      option3: string;
     }`, 'bug-62-default-params', {option1: 'foo', option2: true, option3: 'nope'});
   ok('bug-xxx-method-params');
   ok('bug-59-type-annotation-in-loop', 'foo');
@@ -473,7 +473,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    false`, 'object-method', false, 'bob@example.com');
+    boolean`, 'object-method', false, 'bob@example.com');
   ok('object-properties', 'bob', 'bob@example.com');
   failStatic('bad-object-properties', 'bob', 'bob@example.com');
   failWith(`
@@ -483,7 +483,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    false`, 'object-properties', false, 'bob@example.com');
+    boolean`, 'object-properties', false, 'bob@example.com');
   failWith(`
     Value of "user.email" violates contract.
 
@@ -491,7 +491,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    false`, 'object-properties', 'bob', false);
+    boolean`, 'object-properties', 'bob', false);
   ok('class-getter', 'alice');
   failStatic('bad-class-getter', 'alice');
   ok('class-setter', 'alice');
@@ -503,7 +503,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    123`, 'class-setter', 123);
+    number`, 'class-setter', 123);
   ok('class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
@@ -520,7 +520,7 @@ describe('Typecheck', function () {
     "GB" | "US" | "FR" | "CA"
 
     Got:
-    "Invalid"`, 'class-properties-complex', 'sally', 'bob@example.com', {
+    string`, 'class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
     pos: {
@@ -536,7 +536,7 @@ describe('Typecheck', function () {
     "GB" | "US" | "FR" | "CA"
 
     Got:
-    false`, 'class-properties-complex', 'sally', 'bob@example.com', {
+    boolean`, 'class-properties-complex', 'sally', 'bob@example.com', {
     address: '123 Fake Street',
     country: 'FR',
     pos: {
@@ -560,7 +560,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    false`, 'class-properties', false, 'bob@example.com');
+    boolean`, 'class-properties', false, 'bob@example.com');
   ok('string-literal-annotations', 'foo');
   ok('string-literal-annotations', 'bar');
   failWith(`
@@ -570,7 +570,7 @@ describe('Typecheck', function () {
     "foo" | "bar"
 
     Got:
-    "wat"`, 'string-literal-annotations', 'wat');
+    string`, 'string-literal-annotations', 'wat');
   failStatic('bad-string-literal-annotations', 'foo');
 
   ok('boolean-literal-annotations', true);
@@ -582,7 +582,7 @@ describe('Typecheck', function () {
     true | false
 
     Got:
-    "wat"`, 'boolean-literal-annotations', 'wat');
+    string`, 'boolean-literal-annotations', 'wat');
 
   ok('numeric-literal-annotations', 1);
   ok('numeric-literal-annotations', 2);
@@ -593,7 +593,7 @@ describe('Typecheck', function () {
     1 | 2
 
     Got:
-    3`, 'numeric-literal-annotations', 3);
+    number`, 'numeric-literal-annotations', 3);
 
   ok('enum', 'active');
   ok('enum', 'inactive');
@@ -604,7 +604,7 @@ describe('Typecheck', function () {
     "active" | "inactive"
 
     Got:
-    "pending"`, 'enum', 'pending');
+    string`, 'enum', 'pending');
 
   ok('pragma-ignore-statement', 'some string');
   ok('pragma-ignore-file', 'some string');
@@ -618,7 +618,7 @@ describe('Typecheck', function () {
     string[]
 
     Got:
-    [123]`, 'async-function', [123]);
+    number[]`, 'async-function', [123]);
   failStatic('bad-async-function', 'hello world');
   ok('class-getter', 'alice');
   ok("bug-xxx-export");
@@ -631,7 +631,7 @@ describe('Typecheck', function () {
     Symbol
 
     Got:
-    "wat"`, 'symbols', 'wat');
+    string`, 'symbols', 'wat');
   ok('export-typed-var', 'foo');
   ok('bug-48-export-star', 'wat');
   ok('typeof', {name: 'bob'});
@@ -643,7 +643,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "name": false
+      name: boolean;
     }`, 'typeof', {name: false});
   ok('typeof-class', 'bob');
   failWith(`
@@ -653,7 +653,7 @@ describe('Typecheck', function () {
     typeof user
 
     Got:
-    "nope"`, 'typeof-class', false);
+    string`, 'typeof-class', false);
 
   ok('intersection', {name: 'bob', address: '123 Fake Street'});
   failWith(`
@@ -664,8 +664,8 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "name": "bob",
-      "address": false
+      name: string;
+      address: boolean;
     }`, 'intersection', {name: 'bob', address: false});
 
   ok('set-entries', new Set([1, 2, 3]));
@@ -713,7 +713,7 @@ describe('Typecheck', function () {
     string[]
 
     Got:
-    ["foo", 123]`, 'array-type-annotation', ['foo', 123]);
+    [string, number]`, 'array-type-annotation', ['foo', 123]);
 
   ok('infer-member-expression-from-object', {name: "bob"});
   ok('logical-expression', 'foo');
@@ -747,7 +747,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "a": 123
+      a: number;
     }`, "conditional-return-value", {a: 123});
 
 
@@ -770,7 +770,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "foo": "bar"
+      foo: string;
     }`, "return-object-types", {foo: "bar"});
 
   ok("nested-object-types", {greeting: "hello world", id: 123, nested: {left: 10, right: 20}});
@@ -787,7 +787,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "foo": "bar"
+      foo: string;
     }`, "nested-object-types", {foo: "bar"});
   failWith(`
     Value of argument "input" violates contract.
@@ -802,11 +802,12 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "greeting": "hello world",
-      "id": 123,
-      "nested": {
-        "left": true, "right": false
-      }
+      greeting: string;
+      id: number;
+      nested: {
+        left: boolean;
+        right: boolean;
+      };
     }`, "nested-object-types", {greeting: "hello world", id: 123, nested: {left: true, right: false}});
   failWith(`
     Value of argument "input" violates contract.
@@ -821,11 +822,11 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "greeting": "hello world",
-      "id": 123,
-      "nested": {
-        "left": 10
-      }
+      greeting: string;
+      id: number;
+      nested: {
+        left: number;
+      };
     }`, "nested-object-types", {greeting: "hello world", id: 123, nested: {left: 10}});
   failWith(`
     Value of argument "input" violates contract.
@@ -840,12 +841,12 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "greeting": "hello world",
-      "id": "123",
-      "nested": {
-      "left": 10,
-      "right": 20
-    }
+      greeting: string;
+      id: string;
+      nested: {
+        left: number;
+        right: number;
+      };
     }
     `, "nested-object-types", {greeting: "hello world", id: "123", nested: {left: 10, right: 20}});
 
@@ -860,7 +861,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "foo": "bar"
+      foo: string;
     }`, "complex-object-types", {foo: "bar"});
   failWith(`
     Value of argument "input" violates contract.
@@ -871,7 +872,7 @@ describe('Typecheck', function () {
     }
 
     Got:
-    "foo"`, "complex-object-types", "foo");
+    string`, "complex-object-types", "foo");
 
   ok("any-return-value");
   ok("callexpr-return-value");
@@ -900,7 +901,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    123`,
+    number`,
     "string-arguments",
     123);
 
@@ -924,7 +925,7 @@ describe('Typecheck', function () {
     string | Array<string>
 
     Got:
-    123`, "poly-args", 123);
+    number`, "poly-args", 123);
   failWith(`
     Value of argument \"fn\" violates contract.
 
@@ -932,7 +933,7 @@ describe('Typecheck', function () {
     Function | RegExp
 
     Got:
-    123`, "poly-args", "hello", 123);
+    number`, "poly-args", "hello", 123);
 
   ok("bug-7-class-support");
   ok("bug-8-class-support");
@@ -950,8 +951,8 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "greeting": "hello world",
-      "id": "123"
+      greeting: string;
+      id: string;
     }`, "optional-properties", {greeting: "hello world", id: "123"});
   failWith(`
     Value of argument "input" violates contract.
@@ -963,8 +964,8 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "greeting": "hello world",
-      "id": null
+      greeting: string;
+      id: null;
     }`, "optional-properties", {greeting: "hello world", id: null});
   failWith(`
     Value of argument "input" violates contract.
@@ -976,7 +977,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "id": 123
+      id: number;
     }`, "optional-properties", {id: 123});
   failWith(`
     Value of argument "input" violates contract.
@@ -988,7 +989,7 @@ describe('Typecheck', function () {
 
     Got:
     {
-      "foo": "bar"
+      foo: string;
     }`, "optional-properties", {foo: "bar"});
   failWith(`
     Value of argument "input" violates contract.
@@ -999,7 +1000,7 @@ describe('Typecheck', function () {
     }
 
     Got:
-    "foo"`, "optional-properties", "foo");
+    string`, "optional-properties", "foo");
 
   ok("optional-arguments", "hello world");
   ok("optional-arguments", "hello world", 123);
@@ -1010,7 +1011,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "123"`, "optional-arguments", "hello world", "123");
+    string`, "optional-arguments", "hello world", "123");
   failWith(`
     Value of optional argument "bar" violates contract.
 
@@ -1029,7 +1030,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "123"`, "default-arguments", "hello world", "123");
+    string`, "default-arguments", "hello world", "123");
   failWith(`
     Value of argument "bar" violates contract.
 
@@ -1047,7 +1048,7 @@ describe('Typecheck', function () {
     T.Object | T.Array
 
     Got:
-    "hello"`, "qualified-types", "hello")
+    string`, "qualified-types", "hello")
 
   ok("var-declarations", ["abc", "123"])
   failWith(`
@@ -1057,7 +1058,7 @@ describe('Typecheck', function () {
     Array
 
     Got:
-    "abc"`, "var-declarations", "abc")
+    string`, "var-declarations", "abc")
   failWith(`
     Value of variable "b" violates contract.
 
@@ -1065,7 +1066,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    123`, "var-declarations", ["abc", 123])
+    number`, "var-declarations", ["abc", 123])
 
   ok("var-declarations-2", ["abc", "123"])
   ok("var-declarations-2", ["abc", "1"])
@@ -1076,7 +1077,7 @@ describe('Typecheck', function () {
     Array
 
     Got:
-    "abc"`, "var-declarations-2", "abc")
+    string`, "var-declarations-2", "abc")
   failWith(`
     Value of variable "b" violates contract.
 
@@ -1084,7 +1085,7 @@ describe('Typecheck', function () {
     string
 
     Got:
-    123`, "var-declarations-2", ["abc", 123])
+    number`, "var-declarations-2", ["abc", 123])
 
   ok("arrow-function", 123);
   ok("arrow-function-2", 123);
@@ -1096,7 +1097,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "abc"`, "arrow-function", "abc")
+    string`, "arrow-function", "abc")
   failWith(`
     Value of argument "arg" violates contract.
 
@@ -1104,7 +1105,7 @@ describe('Typecheck', function () {
     number
 
     Got:
-    "abc"`, "arrow-function-2", "abc")
+    string`, "arrow-function-2", "abc")
 
   ok("bug-30-conditional-return");
 


### PR DESCRIPTION
This greatly reduces the size and increases readability of the outputted checks.