### PR TITLE
fix import and export type working around babel T6730

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,7 @@ export default function ({types: t, template}): Object {
       const right: NodePath = path.get('right');
       const rightAnnotation: TypeAnnotation = getAnnotation(right);
       const leftAnnotation: TypeAnnotation = left.isVariableDeclaration() ? getAnnotation(left.get('declarations')[0].get('id')) : getAnnotation(left);
-      if (rightAnnotation.type !== 'VoidTypeAnnotation') {
+      if (rightAnnotation.type !== 'VoidTypeAnnotation' && rightAnnotation.type !== 'NullLiteralTypeAnnotation') {
         const ok: ?boolean = maybeIterableAnnotation(rightAnnotation);
         if (ok === false) {
           throw path.buildCodeFrameError(`Cannot iterate ${humanReadableType(rightAnnotation)}.`);
@@ -1056,6 +1056,7 @@ export default function ({types: t, template}): Object {
       case 'IntersectionTypeAnnotation':
         return intersectionComparer(a, b, compareObjectAnnotation);
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
       case 'BooleanTypeAnnotation':
       case 'BooleanLiteralTypeAnnotation':
       case 'StringTypeAnnotation':
@@ -1103,6 +1104,7 @@ export default function ({types: t, template}): Object {
       case 'IntersectionTypeAnnotation':
         return intersectionComparer(a, b, compareArrayAnnotation);
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
       case 'BooleanTypeAnnotation':
       case 'BooleanLiteralTypeAnnotation':
       case 'StringTypeAnnotation':
@@ -1158,6 +1160,7 @@ export default function ({types: t, template}): Object {
       case 'IntersectionTypeAnnotation':
         return intersectionComparer(a, b, compareTupleAnnotation);
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
       case 'BooleanTypeAnnotation':
       case 'BooleanLiteralTypeAnnotation':
       case 'StringTypeAnnotation':
@@ -1190,6 +1193,7 @@ export default function ({types: t, template}): Object {
         return compareNullableAnnotation(a, b.typeAnnotation);
       case 'NullableTypeAnnotation':
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
         return null;
     }
     if (compareAnnotations(a.typeAnnotation, b) === true) {
@@ -1633,6 +1637,7 @@ export default function ({types: t, template}): Object {
       case 'NullableTypeAnnotation':
         return checks.nullable({input, type: annotation.typeAnnotation, scope});
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
         return checks.void({input});
     }
   }
@@ -2106,7 +2111,7 @@ export default function ({types: t, template}): Object {
           const id = target.get('property').node;
           for (let {key, value} of annotation.properties || []) {
             if (key.name === id.name) {
-              return value.type === 'VoidTypeAnnotation' ? t.anyTypeAnnotation() : value;
+              return (value.type === 'VoidTypeAnnotation' || value.type === 'NullLiteralTypeAnnotation') ? t.anyTypeAnnotation() : value;
             }
           }
       }
@@ -2454,6 +2459,7 @@ export default function ({types: t, template}): Object {
     switch (annotation.type) {
       case 'NullableTypeAnnotation':
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
       case 'MixedTypeAnnotation':
         return true;
       case 'TypeAnnotation':
@@ -2553,6 +2559,7 @@ export default function ({types: t, template}): Object {
           return null;
         }
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
         if (expected.name === 'Array' || expected.name === 'RegExp' || expected.name === 'Error' || expected.name === 'Function' || expected.name === 'String' || expected.name === 'Object') {
           return false;
         }
@@ -2661,6 +2668,7 @@ export default function ({types: t, template}): Object {
       case 'NumericLiteralTypeAnnotation':
       case 'NumberTypeAnnotation':
       case 'VoidTypeAnnotation':
+      case 'NullLiteralTypeAnnotation':
         return false;
       default:
         return null;

--- a/test/fixtures/bad-return-value.js
+++ b/test/fixtures/bad-return-value.js
@@ -1,3 +1,3 @@
 export default function demo (): Object {
-  return false;
+  return null;
 }


### PR DESCRIPTION
Right now `import type {something} from "foo"` doesn't work in babel 6 due to https://phabricator.babeljs.io/T6730

This works around the problem but requires that `babel-plugin-transform-es2015-instanceof` is enabled.