### PR TITLE
allow async functions to return Promise<T>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -398,6 +398,9 @@ export default function ({types: t, template}): Object {
       if (isGeneratorAnnotation(annotation)) {
         annotation = annotation.typeParameters && annotation.typeParameters.params.length > 1 ? annotation.typeParameters.params[1] : t.anyTypeAnnotation();
       }
+      else if (node.async && annotation.type === 'GenericTypeAnnotation' && annotation.id.name === 'Promise') {
+        annotation = (annotation.typeParameters && annotation.typeParameters[0]) || t.anyTypeAnnotation();
+      }
       const ok = staticCheckAnnotation(path.get("argument"), annotation);
       if (ok === true) {
         return;
@@ -712,6 +715,9 @@ export default function ({types: t, template}): Object {
     }
     if (isGeneratorAnnotation(annotation)) {
       annotation = annotation.typeParameters && annotation.typeParameters.params.length > 1 ? annotation.typeParameters.params[1] : t.anyTypeAnnotation();
+    }
+    else if (node.async && annotation.type === 'GenericTypeAnnotation' && annotation.id.name === 'Promise') {
+      annotation = (annotation.typeParameters && annotation.typeParameters[0]) || t.anyTypeAnnotation();
     }
     const name = scope.generateUidIdentifierBasedOnNode(node);
     const id = scope.generateUidIdentifier('id');


### PR DESCRIPTION
> Work in progress.

Async functions should allow `Promise<T>` as their annotation as well as `T`. Right now we're incompatible with flow which only allows `Promise<T>`.

As part of this we should also allow returning instances of `Promise`, probably via a check for `.then()` rather than `instanceof`.

ping @tp
