### PR TITLE
Create React propTypes from props annotations

### DIFF
--- a/test/fixtures/react-parameterized.js
+++ b/test/fixtures/react-parameterized.js
@@ -1,0 +1,20 @@
+const React = Object;
+
+type Props = {
+  bar: string;
+}
+
+class Foo extends React<void,Props,void> {
+
+  render() {
+
+  }
+
+}
+
+export default function demo (props) {
+  const error = Foo.propTypes.bar(props, 'bar', 'Foo');
+  if (error) {
+    throw error;
+  }
+}

--- a/test/fixtures/react-proptypes.js
+++ b/test/fixtures/react-proptypes.js
@@ -1,0 +1,20 @@
+const React = Object;
+
+class Foo extends React {
+
+  props: {
+    bar: string;
+  };
+
+  render() {
+
+  }
+
+}
+
+export default function demo (props) {
+  const error = Foo.propTypes.bar(props, 'bar', 'Foo');
+  if (error) {
+    throw error;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,17 @@ else {
 
 describe('Typecheck', function () {
 
+  ok('react-parameterized', {bar: 'bar'});
+  failWith(`
+    Invalid prop \`bar\` supplied to \`Foo\`.
+
+    Expected:
+    string
+
+    Got:
+    number
+  `, 'react-parameterized', {bar: 3});
+
   ok('react-proptypes', {bar: 'bar'});
   failWith(`
     Invalid prop \`bar\` supplied to \`Foo\`.

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,17 @@ else {
 }
 
 describe('Typecheck', function () {
+
+  ok('react-proptypes', {bar: 'bar'});
+  failWith(`
+    Invalid prop \`bar\` supplied to \`Foo\`.
+
+    Expected:
+    string
+
+    Got:
+    number
+  `, 'react-proptypes', {bar: 3});
   ok('bug-108-default-value', {y: ''});
   failWith(`
     Value of argument 0 violates contract.


### PR DESCRIPTION
These changes add a propTypes object to a class based on the type annotations you specify. This transformation is only applied when:
- The class has a superclass and a render method
- There is no existing propTypes
- The props property is an object type

Example:

``` js
export class Foo extends Component {

    props: {
        user: ?string;
    };

    render() {
        return <div>Hello, {this.props.user || "World"}!</div>;
    }

}
```

becomes

``` js
export class Foo extends Component {

    render() {
        return React.createElement(
            "div",
            null,
            "Hello, ",
            this.props.user || "World",
            "!"
        );
    }

}
Foo.propTypes = {
    user: function (props, name, component) {
        var prop = props[name];

        if (!(prop == null || typeof prop === 'string')) {
            return new Error("Invalid prop `" + name + "` supplied to `" + component + "`.\n\nExpected:\n" + "?string" + "\n\nGot:\n" + _inspect(prop) + "\n\n");
        }
    }
};
```

I've tested this on a small app and it works so far.
