### PR TITLE
true file level opt-in

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ export default function ({types: t, template}): Object {
       var prop = props[name];
       if(!check) {
         return new Error(
-          "Invalid prop \`" + name + "\` supplied to \`" + component 
+          "Invalid prop \`" + name + "\` supplied to \`" + component
           + "\`.\\n\\nExpected:\\n" + expected + "\\n\\nGot:\\n" + got + "\\n\\n"
         );
       }
@@ -3244,7 +3244,7 @@ export default function ({types: t, template}): Object {
    */
   function mustCheckFile(path: NodePath, opts): boolean {
     if (path.node.leadingComments && path.node.leadingComments.length) {
-      return !skipEnvironment(path.node.leadingComments, opts);
+      return opts.only && !skipEnvironment(path.node.leadingComments, opts);
     }
     return false;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -726,9 +726,18 @@ export default function ({types: t, template}): Object {
         if (opts && opts.disable && opts.disable[process.env.NODE_ENV]) {
           return;
         }
+        let checkFile = false;
         for (let child of path.get('body')) {
-          if (maybeSkipFile(child, opts)) {
-            return;
+          if (mustCheckFile(child, opts)) {
+            checkFile = true;
+            break;
+          }
+        }
+        if (!checkFile) {
+          for (let child of path.get('body')) {
+            if (maybeSkipFile(child, opts)) {
+              return;
+            }
           }
         }
         const inspect = path.scope.generateUidIdentifier('inspect');
@@ -3232,6 +3241,15 @@ export default function ({types: t, template}): Object {
     }
   }
 
+  /**
+   * Determine whether the file should be checked
+   */
+  function mustCheckFile(path: NodePath, opts): boolean {
+    if (path.node.leadingComments && path.node.leadingComments.length) {
+      return !skipEnvironment(path.node.leadingComments, opts);
+    }
+    return false;
+  }
   /**
    * Determine whether the file should be skipped, based on the comments attached to the given node.
    */

--- a/test/fixtures/pragma-opt-in.js
+++ b/test/fixtures/pragma-opt-in.js
@@ -1,2 +1,6 @@
-// @typecheck: some, production, demo
+/* @typecheck: some, production, demo */
+
+function bar() {}
+
+// some some
 export default function demo(args: string) {}


### PR DESCRIPTION
Previously we checked the comments leading to any top level symbol
for the opt in pragma this caused the file to be skipped if any of
the top level symbols was missing the opt in pragma. Now, if any of
the top level comments has the opt in pragma and the environments
match the file will be included.