### PR TITLE
Fix React propTypes in combination with decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
   "devDependencies": {
     "babel-cli": "^6.1.0",
     "babel-core": "^6.1.0",
-    "babel-plugin-syntax-flow": "^6.0.14",
     "babel-plugin-syntax-class-properties": "^6.1.18",
+    "babel-plugin-syntax-flow": "^6.0.14",
+    "babel-plugin-transform-decorators-legacy": "^1.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
     "babel-plugin-transform-flow-strip-types": "^6.0.14",
     "babel-polyfill": "^6.0.16",

--- a/test/fixtures/react-decorator.js
+++ b/test/fixtures/react-decorator.js
@@ -1,0 +1,26 @@
+const Component = Object;
+let _tmp;
+
+function decorator(Component) {
+  _tmp = Component;
+  return true;
+}
+
+@decorator
+class Foo extends Component {
+
+  props: {
+    bar: string;
+  };
+
+  render() {
+  }
+
+}
+
+export default function demo (props) {
+  const error = _tmp.propTypes.bar(props, 'bar', 'Foo');
+  if (error) {
+    throw error;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ else {
 
 describe('Typecheck', function () {
 
+  ok('react-decorator', {bar: 'bar'});
   ok('react-parameterized', {bar: 'bar'});
   failWith(`
     Invalid prop \`bar\` supplied to \`Foo\`.
@@ -1229,6 +1230,7 @@ function loadInternal (basename, opts) {
     plugins: [
       opts ? [typecheck, opts] : typecheck,
       'transform-flow-strip-types',
+      'transform-decorators-legacy',
       'syntax-class-properties'
     ]
   });


### PR DESCRIPTION
When using a decorator that introduces a higher order class, the propTypes where assigned to the wrong class.

I did not include a unit test for this, as decorators currently require a non-standard transformation to work. I can add one if this is not a problem.

This patch assumes that you have the class properties transformation enabled if you have are using decorators (because there is no simple way to assign things to the prototype of the decorated class without them).