### PR TITLE
Fix build errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -977,13 +977,13 @@ export default function ({types: t, template}): Object {
         const type = createTypeExpression(annotation.id);
 
         const {node, scope} = path;
-        if (type.name === 'Object' && node.type === 'ObjectExpression' && !scope.hasBinding('Object')) {
+        if (type.name === 'Object' && node.type === 'ObjectExpression' && !scope.getBinding('Object')) {
           return true;
         }
-        else if (type.name === 'Map' && !scope.hasBinding('Map')) {
+        else if (type.name === 'Map' && !scope.getBinding('Map')) {
           return null;
         }
-        else if (type.name === 'Set' && !scope.hasBinding('Set')) {
+        else if (type.name === 'Set' && !scope.getBinding('Set')) {
           return null;
         }
         else if (type.name === 'Class' && !scope.hasBinding('Class')) {
@@ -1665,10 +1665,10 @@ export default function ({types: t, template}): Object {
         else if (annotation.id.name === 'Iterable' && !scope.hasBinding('Iterable')) {
           return checks.iterable({input, types: annotation.typeParameters ? annotation.typeParameters.params : [], scope});
         }
-        else if (annotation.id.name === 'Map' && !scope.hasBinding('Map')) {
+        else if (annotation.id.name === 'Map' && !scope.getBinding('Map')) {
           return checks.map({input, types: annotation.typeParameters ? annotation.typeParameters.params : [], scope});
         }
-        else if (annotation.id.name === 'Set' && !scope.hasBinding('Set')) {
+        else if (annotation.id.name === 'Set' && !scope.getBinding('Set')) {
           return checks.set({input, types: annotation.typeParameters ? annotation.typeParameters.params : [], scope});
         }
         else if (annotation.id.name === 'Function') {
@@ -1704,7 +1704,7 @@ export default function ({types: t, template}): Object {
         else if (annotation.id.name === 'double' && !scope.hasBinding('double')) {
           return checks.double({input});
         }
-        else if (annotation.id.name === 'Symbol' && !scope.hasBinding('Symbol')) {
+        else if (annotation.id.name === 'Symbol' && !scope.getBinding('Symbol')) {
           return checks.symbol({input});
         }
         else if (isTypeChecker(annotation.id, scope)) {
@@ -1871,8 +1871,6 @@ export default function ({types: t, template}): Object {
           return getArrayExpressionAnnotation(path);
         case 'ObjectExpression':
           return getObjectExpressionAnnotation(path);
-        case 'BinaryExpression':
-          return getBinaryExpressionAnnotation(path);
         case 'BinaryExpression':
           return getBinaryExpressionAnnotation(path);
         case 'LogicalExpression':

--- a/test/index.js
+++ b/test/index.js
@@ -51,8 +51,7 @@ describe('Typecheck', function () {
     Value of variable "k" violates contract.
 
     Expected:
-    { captureTime: number
-    }
+    BasicSeq
 
     Got:
     { x: number;
@@ -74,9 +73,7 @@ describe('Typecheck', function () {
     Function "demo" return value violates contract.
 
     Expected:
-    {
-      [key: string]: string | number
-    }
+    Thing
 
     Got:
     {
@@ -92,10 +89,7 @@ describe('Typecheck', function () {
     Function "demo" return value violates contract.
 
     Expected:
-    { bool: bool;
-      bools: bool[];
-      [key: string]: string | number;
-    }
+    Thing
 
     Got:
     {
@@ -606,7 +600,7 @@ describe('Typecheck', function () {
     Value of "user.location.country" violates contract.
 
     Expected:
-    "GB" | "US" | "FR" | "CA"
+    CountryCode
 
     Got:
     string`, 'class-properties-complex', 'sally', 'bob@example.com', {
@@ -622,7 +616,7 @@ describe('Typecheck', function () {
     Value of "user.location.country" violates contract.
 
     Expected:
-    "GB" | "US" | "FR" | "CA"
+    CountryCode
 
     Got:
     boolean`, 'class-properties-complex', 'sally', 'bob@example.com', {
@@ -690,7 +684,7 @@ describe('Typecheck', function () {
     Value of argument "input" violates contract.
 
     Expected:
-    "active" | "inactive"
+    status
 
     Got:
     string`, 'enum', 'pending');


### PR DESCRIPTION
Some unit tests are failing with the latest version of Babel.

- Map and Set are always in scope, making the plugin revert to generic type checks because it thinks they are overridden.
- The path cache was removed in https://phabricator.babeljs.io/T7179 meaning `getNodePath` is not able to find the types, and just reverts to the type name.

I'm not sure how to fix this last issue without propagating the actual path, the issue makes it sound like that shouldn't be possible anymore.