### PR TITLE
allow optional react props

### DIFF
--- a/test/fixtures/react-optional-prop.js
+++ b/test/fixtures/react-optional-prop.js
@@ -8,8 +8,8 @@ class Foo extends React {
   render() {}
 }
 
-export default function demo () {
-  const error = Foo.propTypes.bar({bar: undefined}, 'bar', 'Foo');
+export default function demo (props) {
+  const error = Foo.propTypes.bar(props, 'bar', 'Foo');
   if (error) {
     throw error;
   }

--- a/test/fixtures/react-optional-prop.js
+++ b/test/fixtures/react-optional-prop.js
@@ -1,0 +1,16 @@
+const React = Object;
+
+class Foo extends React {
+  props: {
+    bar?: string;
+  };
+
+  render() {}
+}
+
+export default function demo () {
+  const error = Foo.propTypes.bar({bar: undefined}, 'bar', 'Foo');
+  if (error) {
+    throw error;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ else {
 
 describe('Typecheck', function () {
 
+  ok('react-optional-prop');
   ok('react-decorator', {bar: 'bar'});
   ok('react-parameterized', {bar: 'bar'});
   failWith(`

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,19 @@ else {
 
 describe('Typecheck', function () {
 
-  ok('react-optional-prop');
+  ok('react-optional-prop', {bar: 'hello world'});
+  ok('react-optional-prop', {bar: undefined});
+  ok('react-optional-prop', {});
+  failWith(`
+    Invalid prop \`bar\` supplied to \`Foo\`.
+
+    Expected:
+    string
+
+    Got:
+    null
+  `, 'react-optional-prop', {bar: null});
+
   ok('react-decorator', {bar: 'bar'});
   ok('react-parameterized', {bar: 'bar'});
   failWith(`


### PR DESCRIPTION
I'm surprise I could not find any reported issue about this.

``` js
props: {
  optionalProp?: string,
  nullableProp: ?string,
  optionalAndNullableProps?: ?string,
}
```
