### PR TITLE
fix `func(param: string | null)` allow undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1809,8 +1809,9 @@ export default function ({types: t, template}): Object {
       case 'NullableTypeAnnotation':
         return checks.nullable({input, type: annotation.typeAnnotation, scope});
       case 'VoidTypeAnnotation':
-      case 'NullLiteralTypeAnnotation':
         return checks.void({input});
+      case 'NullLiteralTypeAnnotation':
+        return checks.null({input});
     }
   }
 


### PR DESCRIPTION
Flowtype not allow `((param: string | null) => {})(undefined)`: https://flowtype.org/try/#0PQKgBAAgZgNg9gdzCYAoVAKDAHAhgJ1wFsAuMAZwBd8BLAOwHMwAfMOgVxhgEowBeAHxgA3gF9uGdnQAmAUyj1Z07kA

I found typecheck will check the type like: `typeof param === 'string' || param == null`

But the test file seems intricate, I have no idea about how to add a new test...